### PR TITLE
欲しいもののAmazon URLから画像と値段を取得できるようにした。

### DIFF
--- a/lib/goalset.dart
+++ b/lib/goalset.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:intl/intl.dart';
 import 'home.dart';
+import 'package:universal_html/controller.dart';
 
 class GoalSetPage extends StatefulWidget {
   @override
@@ -148,6 +149,15 @@ class _GoalSetPageState extends State<GoalSetPage> {
   void submitPressed() async {
     final createdAt = DateFormat.yMMMMEEEEd().add_jms().format(DateTime.now());
 
+    final controller = WindowController();
+    await controller.openHttp(
+      uri: Uri.parse(wantThingController.text),
+    );
+
+    final imgContainer = controller.window.document.querySelector("#imgTagWrapperId");
+    final wantThingImg = imgContainer.querySelectorAll("img").first.getAttribute("src");
+    final wantThingPrice = controller.window.document.querySelectorAll("span.priceBlockBuyingPriceString").first.text;
+
     await FirebaseFirestore.instance
       .collection('goals')
       .doc()
@@ -156,7 +166,8 @@ class _GoalSetPageState extends State<GoalSetPage> {
         'userName': userName,
         'userPhotoUrl': userPhoto,
         'goalText': goalTextController.text,
-        'wantThing': wantThingController.text,
+        'wantThingImg': wantThingImg,
+        'wantThingPrice': wantThingPrice,
         'createdAt' : createdAt,
       });
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,10 +26,11 @@ dependencies:
   firebase_core: ^1.0.2
   firebase_auth: ^1.0.1
   cloud_firestore: ^1.0.3
-  firebase_analytics: ^7.1.1
+  firebase_analytics: ^8.0.0
   firebase_storage: ^8.0.1
   wave_progress_widget: ^0.0.1
   intl: ^0.17.0
+  universal_html: ^2.0.8
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
作業点
---
- universal_html パッケージを用い、欲しいもののAmazon URLから画像と値段を取得できるようにした。
- 取得した画像と値段は、cloud firestoreの「goals」コレクションに、基本的な情報とともに保存されるようにした。
<img width="916" alt="スクリーンショット 2021-04-18 21 05 05" src="https://user-images.githubusercontent.com/44431841/115144849-d6d24400-a089-11eb-9e58-b8b12f1000ad.png">

---
なお、公式ドキュメントのUsageが曖昧で不足気味（少し間違っていたところも？）だったので、別の技術調査issueに記載する予定。
