### PR TITLE
目的一覧・追加ページの増設とアプリ調整

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -43,6 +43,11 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>https</string>
+		<string>http</string>
+	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
 </dict>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,17 +1,20 @@
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'views/signup.dart';
 import 'views/login.dart';
+import 'views/goalselect.dart';
 import 'configs/colors.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  await Firebase.initializeApp();
   runApp(MyApp());
 }
 
 class MyApp extends StatelessWidget {
-  final Future<FirebaseApp> _fbApp = Firebase.initializeApp();
   //final UserState userState = UserState();
+  final user = FirebaseAuth.instance.currentUser;
 
   // This widget is the root of your application.
   @override
@@ -23,21 +26,7 @@ class MyApp extends StatelessWidget {
         visualDensity: VisualDensity.adaptivePlatformDensity,
         fontFamily: 'Yu Gothic',
       ),
-      home: FutureBuilder(
-        future: _fbApp,
-        builder: (context, snapshot) {
-          if (snapshot.hasError) {
-            print('You have an error! ${snapshot.error.toString()}');
-            return Text('Something went wrong!');
-          } else if (snapshot.hasData) {
-            return StartPage();
-          } else {
-            return Center(
-              child: CircularProgressIndicator(),
-            );
-          }
-        },
-      )
+      home: (user == null) ? StartPage() : GoalSelectPage(),
     );
   }
 }

--- a/lib/models/upload_image.dart
+++ b/lib/models/upload_image.dart
@@ -22,8 +22,8 @@ class UploadImage {
     return pickedFile.path;
   }
 
-  static Future<void> uploadFile(imagePath, userEmail) async {
+  static Future<void> uploadFile(imagePath, userId) async {
     File file = File(imagePath);
-    await storage.ref('userImages/'+userEmail+'.png').putFile(file);
+    await storage.ref('user/'+userId+'/'+userId).putFile(file);
   }
 }

--- a/lib/views/goalselect.dart
+++ b/lib/views/goalselect.dart
@@ -1,0 +1,181 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_storage/firebase_storage.dart' as firebase_storage;
+import 'package:my_gaman_app/views/goalset.dart';
+import '../configs/colors.dart';
+import 'home.dart';
+
+class GoalSelectPage extends StatefulWidget {
+  @override
+  _GoalSelectPageState createState() => _GoalSelectPageState();
+}
+
+class _GoalSelectPageState extends State<GoalSelectPage> {
+
+  firebase_storage.FirebaseStorage storage = firebase_storage.FirebaseStorage.instance; 
+
+  var user = FirebaseAuth.instance.currentUser;
+  var userId;
+  var userName;
+  var userPhoto;
+
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    if (user != null) {
+      setData();
+    }
+  }
+
+  void setData() async {
+    userId = user.uid;
+    userName = user.displayName;
+    userPhoto = user.photoURL;
+
+    setState(() {
+      _loading = false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading) {
+      return Center(
+        child: CircularProgressIndicator()
+      );
+    }
+
+    return Scaffold(
+      backgroundColor: AppColor.bgColor,
+      appBar: AppBar(
+        iconTheme: IconThemeData(color: Colors.grey),
+        title: Text(
+          '目的一覧',
+          style: TextStyle(
+            color:AppColor.textColor,
+            fontWeight: FontWeight.w500,
+          ),
+        ),
+        backgroundColor: AppColor.white,
+        shadowColor: AppColor.shadow,
+      ),
+
+      body: Container(
+        color: AppColor.bgColor,
+        margin: EdgeInsets.only(top: 20),
+        padding: EdgeInsets.only(left: 10, right: 10),
+        child: Column(
+          children: <Widget>[
+            Expanded(
+              child: FutureBuilder<QuerySnapshot>(
+                future: FirebaseFirestore.instance
+                  .collection('goals')
+                  .where('userId', isEqualTo: userId)
+                  .orderBy('createdAt', descending: true)
+                  .get(),
+                builder: (context, snapshot) {
+                  if (!snapshot.hasData) {
+                    return Center(
+                      child: CircularProgressIndicator()
+                    );
+                  }
+                  final List<DocumentSnapshot> documents = snapshot.data.docs;
+                  return ListView(
+                    children: documents.map((document) {
+                      //final othersPhoto = storage.ref(document['userPhoto']);
+                      //final othersPhotoUrl = getDownloadUrl(othersPhoto);
+                      return Card(
+                        margin: EdgeInsets.all(0.5),
+                        elevation: 2.0,
+                        child: InkWell(
+                          onTap: () {
+                            Navigator.of(context).pushReplacement(
+                              MaterialPageRoute(builder: (context) => HomePage(document.id)),
+                            );
+                          },
+                          child: Padding(
+                            padding: EdgeInsets.all(5.0),
+                            child: ListTile(
+                              leading: Container(
+                                height: 100.0,
+                                width: 100.0,
+                                decoration: BoxDecoration(
+                                  borderRadius: BorderRadius.circular(8.0),
+                                  image: DecorationImage(
+                                    image: NetworkImage(document['wantThingImg']),
+                                    fit: BoxFit.contain,
+                                  ),
+                                ),
+                              ),
+                              title: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: <Widget>[
+                                  Text(
+                                    document['date'],
+                                    style: TextStyle(
+                                      fontSize: 9.0,
+                                      fontWeight: FontWeight.w300,
+                                    ),
+                                  ),
+                                  Text(
+                                    document['goalText'],
+                                    style: TextStyle(
+                                      fontSize: 14.0,
+                                      fontWeight: FontWeight.w600,
+                                    )
+                                  ),
+                                ],
+                              ),
+                              subtitle: Column(
+                                mainAxisAlignment: MainAxisAlignment.end,
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: <Widget>[
+                                  Padding(padding: EdgeInsets.all(1.0)),
+                                  Text(
+                                    '目標金額：' + document['wantThingPrice'],
+                                    style: TextStyle(
+                                      color: AppColor.textColor,
+                                      fontSize: 15.0,
+                                      fontWeight: FontWeight.w400,
+                                    ),
+                                  ),
+                                ],
+                              ),
+                              trailing: (document['achieve'] == true) ? Icon(Icons.check_box_outlined) : Icon(Icons.check_box_outline_blank),
+                            ),
+                          ),
+                        ),
+                      );
+                    }).toList(),
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          Navigator.of(context).push(
+            MaterialPageRoute(builder: (context) => GoalSetPage()),
+          );
+        },
+        child: Container(
+          alignment: Alignment.center,
+          child: Text(
+            '＋',
+            style: TextStyle(
+              color: AppColor.white,
+              fontSize: 40.0,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+        ),
+        backgroundColor: AppColor.priceColor,
+      ),
+    );
+  }
+}

--- a/lib/views/goalset.dart
+++ b/lib/views/goalset.dart
@@ -17,6 +17,7 @@ class _GoalSetPageState extends State<GoalSetPage> {
   TextEditingController wantThingController = TextEditingController();
 
   var user = FirebaseAuth.instance.currentUser;
+  var userId;
   var userEmail;
   var userName;
   var userPhoto;
@@ -27,6 +28,7 @@ class _GoalSetPageState extends State<GoalSetPage> {
   void initState() {
     super.initState();
     if (user != null) {
+      userId = user.uid;
       userEmail = user.email;
       userName = user.displayName;
       userPhoto = user.photoURL;
@@ -144,7 +146,8 @@ class _GoalSetPageState extends State<GoalSetPage> {
   }
 
   void submitPressed() async {
-    final createdAt = DateFormat.yMMMMEEEEd().add_jms().format(DateTime.now());
+    final time = DateTime.now();
+    final createdAt = Timestamp.fromDate(time);
 
     final controller = WindowController();
     await controller.openHttp(
@@ -159,7 +162,7 @@ class _GoalSetPageState extends State<GoalSetPage> {
       .collection('goals')
       .doc()
       .set({
-        'userEmail': userEmail,
+        'userId': userId,
         'userName': userName,
         'userPhotoUrl': userPhoto,
         'goalText': goalTextController.text,

--- a/lib/views/goalset.dart
+++ b/lib/views/goalset.dart
@@ -166,6 +166,7 @@ class _GoalSetPageState extends State<GoalSetPage> {
         'userName': userName,
         'userPhotoUrl': userPhoto,
         'goalText': goalTextController.text,
+        'wantThingUrl': wantThingController.text,
         'wantThingImg': wantThingImg,
         'wantThingPrice': wantThingPrice,
         'createdAt' : createdAt,

--- a/lib/views/goalset.dart
+++ b/lib/views/goalset.dart
@@ -2,7 +2,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:intl/intl.dart';
-import 'home.dart';
+import 'package:my_gaman_app/views/goalselect.dart';
 import 'package:universal_html/controller.dart';
 import '../configs/colors.dart';
 
@@ -132,6 +132,7 @@ class _GoalSetPageState extends State<GoalSetPage> {
     });
     final time = DateTime.now();
     final createdAt = Timestamp.fromDate(time);
+    final date = DateFormat('yyyy-MM-dd HH:mm').format(time).toString();
 
     final controller = WindowController();
     await controller.openHttp(
@@ -153,17 +154,17 @@ class _GoalSetPageState extends State<GoalSetPage> {
         'wantThingImg': wantThingImg,
         'wantThingPrice': wantThingPrice,
         'createdAt' : createdAt,
+        'date': date,
+        'achieve': false,
       });
 
     goalTextController.clear();
     wantThingController.clear();
 
     await Navigator.of(context).pushReplacement(
-      MaterialPageRoute(builder: (context) => HomePage()),
+      MaterialPageRoute(builder: (context) => GoalSelectPage()),
     );
 
-    setState(() {
-      _loading = false;
-    });
+    _loading = false;
   }
 }

--- a/lib/views/goalset.dart
+++ b/lib/views/goalset.dart
@@ -47,6 +47,7 @@ class _GoalSetPageState extends State<GoalSetPage> {
     }
 
     return Scaffold(
+      resizeToAvoidBottomInset: false,
       backgroundColor: AppColor.white,
       appBar: AppBar(
         iconTheme: IconThemeData(color: Colors.grey),
@@ -57,27 +58,6 @@ class _GoalSetPageState extends State<GoalSetPage> {
         backgroundColor: AppColor.white,
         shadowColor: AppColor.shadow,
       ),
-
-      drawer:Drawer(
-        child: ListView(
-          shrinkWrap: true,
-          children: <Widget>[
-            Card(
-              child: ListTile(
-                leading: FlutterLogo(size: 65.0),
-                title: Text(userName),
-                subtitle: Text(userEmail),
-              )
-            ),
-            Padding(padding: EdgeInsets.all(5.0)),
-            ListTile(
-              leading: const Icon(Icons.ac_unit_sharp),
-              title: Text('testtest'),
-            ),
-          ],
-        ),
-      ),
-
       body: Center(
         child: Container(
           color: AppColor.white,
@@ -90,7 +70,7 @@ class _GoalSetPageState extends State<GoalSetPage> {
               Text(
                 '我慢目的',
                 style: TextStyle(
-                  fontSize: 22.0,
+                  fontSize: 16.0,
                   fontWeight: FontWeight.w500,
                   color: AppColor.shadow,
                 ),
@@ -98,15 +78,15 @@ class _GoalSetPageState extends State<GoalSetPage> {
               TextField(
                 controller: goalTextController,
                 style: TextStyle(
-                  fontSize: 20.0,
+                  fontSize: 18.0,
                   fontWeight: FontWeight.w400,
                 ),
               ),
-              SizedBox(height: 40.0),
+              SizedBox(height: 20.0),
               Text(
                 '欲しいもの',
                 style: TextStyle(
-                  fontSize: 22.0,
+                  fontSize: 16.0,
                   fontWeight: FontWeight.w500,
                   color: AppColor.shadow,
                 ),
@@ -114,11 +94,11 @@ class _GoalSetPageState extends State<GoalSetPage> {
               TextField(
                 controller: wantThingController,
                 style: TextStyle(
-                  fontSize: 20.0,
+                  fontSize: 18.0,
                   fontWeight: FontWeight.w400,
                 ),
               ),
-              Padding(padding: EdgeInsets.all(60.0),),
+              Padding(padding: EdgeInsets.all(30.0),),
               Container(
                 alignment: Alignment.bottomRight,
                 padding: EdgeInsets.all(10.0),
@@ -138,6 +118,7 @@ class _GoalSetPageState extends State<GoalSetPage> {
                   ),
                 ),
               ),
+              Padding(padding: EdgeInsets.all(30.0)),
             ],
           ),
         ),
@@ -146,10 +127,9 @@ class _GoalSetPageState extends State<GoalSetPage> {
   }
 
   void submitPressed() async {
-    await Navigator.of(context).pushReplacement(
-      MaterialPageRoute(builder: (context) => HomePage()),
-    );
-
+    setState(() {
+      _loading = true;
+    });
     final time = DateTime.now();
     final createdAt = Timestamp.fromDate(time);
 
@@ -177,5 +157,13 @@ class _GoalSetPageState extends State<GoalSetPage> {
 
     goalTextController.clear();
     wantThingController.clear();
+
+    await Navigator.of(context).pushReplacement(
+      MaterialPageRoute(builder: (context) => HomePage()),
+    );
+
+    setState(() {
+      _loading = false;
+    });
   }
 }

--- a/lib/views/goalset.dart
+++ b/lib/views/goalset.dart
@@ -146,6 +146,10 @@ class _GoalSetPageState extends State<GoalSetPage> {
   }
 
   void submitPressed() async {
+    await Navigator.of(context).pushReplacement(
+      MaterialPageRoute(builder: (context) => HomePage()),
+    );
+
     final time = DateTime.now();
     final createdAt = Timestamp.fromDate(time);
 
@@ -153,7 +157,6 @@ class _GoalSetPageState extends State<GoalSetPage> {
     await controller.openHttp(
       uri: Uri.parse(wantThingController.text),
     );
-
     final imgContainer = controller.window.document.querySelector("#imgTagWrapperId");
     final wantThingImg = imgContainer.querySelectorAll("img").first.getAttribute("src");
     final wantThingPrice = controller.window.document.querySelectorAll("span.priceBlockBuyingPriceString").first.text;
@@ -174,9 +177,5 @@ class _GoalSetPageState extends State<GoalSetPage> {
 
     goalTextController.clear();
     wantThingController.clear();
-
-    await Navigator.of(context).pushReplacement(
-      MaterialPageRoute(builder: (context) => HomePage()),
-    );
   }
 }

--- a/lib/views/home.dart
+++ b/lib/views/home.dart
@@ -81,7 +81,6 @@ class _HomePageState extends State<HomePage> {
 
     return Scaffold(
       backgroundColor: AppColor.bgColor,
-
       drawer:Drawer(
         child: ListView(
           shrinkWrap: true,
@@ -308,7 +307,7 @@ class _HomePageState extends State<HomePage> {
                               crossAxisAlignment: CrossAxisAlignment.start,
                               children: <Widget>[
                                 Text(
-                                  document['createdAt'],
+                                  document['date'],
                                   style: TextStyle(
                                     fontSize: 12.0,
                                     fontWeight: FontWeight.w300,
@@ -440,7 +439,9 @@ class _HomePageState extends State<HomePage> {
   void submitPressed() async {
     Navigator.pop(context);
 
-    final createdAt = DateFormat.yMMMMEEEEd().add_jms().format(DateTime.now());
+    final time = DateTime.now();
+    final createdAt = Timestamp.fromDate(time);
+    final date = DateTime(time.year, time.month, time.day, time.hour, time.minute);
     gamanPrice = priceController.text;
 
     await FirebaseFirestore.instance
@@ -453,6 +454,7 @@ class _HomePageState extends State<HomePage> {
         'price': gamanPrice,
         'text': descriptionController.text,
         'createdAt': createdAt,
+        'date': date,
         'goalId': goalId, 
       });
 

--- a/lib/views/home.dart
+++ b/lib/views/home.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:wave_progress_widget/wave_progress.dart';
 import 'package:intl/intl.dart';
+import 'package:url_launcher/url_launcher.dart';
 import 'package:firebase_storage/firebase_storage.dart' as firebase_storage;
 import 'postview.dart';
 import 'setting.dart';
@@ -34,6 +35,7 @@ class _HomePageState extends State<HomePage> {
   var wantThingPrice;
   var wantThingImg;
   var goalId;
+  var _url = 'https://www.amazon.co.jp/Dell-21-5%E3%82%A4%E3%83%B3%E3%83%81%E3%83%AF%E3%82%A4%E3%83%89-P2214H-LED%E6%B6%B2%E6%99%B6%E3%83%A2%E3%83%8B%E3%82%BF-1920x1080/dp/B0936FMZW3/ref=sr_1_1_sspa?__mk_ja_JP=%E3%82%AB%E3%82%BF%E3%82%AB%E3%83%8A&dchild=1&keywords=%E3%83%87%E3%82%A3%E3%82%B9%E3%83%97%E3%83%AC%E3%82%A4&qid=1621546723&sr=8-1-spons&spLa=ZW5jcnlwdGVkUXVhbGlmaWVyPUEyUlY1Q1JJUFdaSklPJmVuY3J5cHRlZElkPUEwMzgyODA0M0pXSFNLWDk1RlFKTiZlbmNyeXB0ZWRBZElkPUEyVE9VQ1pKNVpYUklMJndpZGdldE5hbWU9c3BfYXRmJmFjdGlvbj1jbGlja1JlZGlyZWN0JmRvTm90TG9nQ2xpY2s9dHJ1ZQ&th=1';
 
   QuerySnapshot gamanSnapshot;
   List<DocumentSnapshot> documents = [];
@@ -350,6 +352,7 @@ class _HomePageState extends State<HomePage> {
           ),
         ],
       ),
+      
       floatingActionButton: FloatingActionButton(
         onPressed: () {
           submitGaman();
@@ -365,6 +368,10 @@ class _HomePageState extends State<HomePage> {
         backgroundColor: AppColor.priceColor,
       ),
     );
+  }
+
+  void _launchURL() async {
+    await canLaunch(_url) ? await launch(_url) : throw 'Could not launch $_url';
   }
 
   void submitGaman() {
@@ -468,11 +475,44 @@ class _HomePageState extends State<HomePage> {
       saving = saving + int.parse(gamanPrice);
       if (saving >= int.parse(wantThingPrice)) {
         saving = int.parse(wantThingPrice);
-      }
+      } 
       _currentValue = (saving / int.parse(wantThingPrice)) * 100;
     });
     
     priceController.clear();
     descriptionController.clear();
+
+    if (saving >= int.parse(wantThingPrice)) {
+      showDialog(
+        context: context,
+        barrierDismissible: true,
+        builder: (BuildContext context) {
+          return AlertDialog(
+            title: const Text('目標達成！'),
+            content: SingleChildScrollView(
+              child: ListBody(
+                children: <Widget>[
+                  Image.network(wantThingImg),
+                  Text('おめでとうございます！実質貯金が貯まりました。'),
+                  Text('商品ページへ遷移しますか？'),
+                ],
+              ),
+            ),
+            actions: <Widget>[
+              TextButton(
+                child: const Text('OK'),
+                onPressed: _launchURL,
+              ),
+              TextButton(
+                child: const Text('Cancel'),
+                onPressed: () {
+                  Navigator.of(context).pop();
+                },
+              ),
+            ],
+          );
+        },
+      );
+    }
   }
 }

--- a/lib/views/home.dart
+++ b/lib/views/home.dart
@@ -35,7 +35,7 @@ class _HomePageState extends State<HomePage> {
   var wantThingPrice;
   var wantThingImg;
   var goalId;
-  var _url = 'https://www.amazon.co.jp/Dell-21-5%E3%82%A4%E3%83%B3%E3%83%81%E3%83%AF%E3%82%A4%E3%83%89-P2214H-LED%E6%B6%B2%E6%99%B6%E3%83%A2%E3%83%8B%E3%82%BF-1920x1080/dp/B0936FMZW3/ref=sr_1_1_sspa?__mk_ja_JP=%E3%82%AB%E3%82%BF%E3%82%AB%E3%83%8A&dchild=1&keywords=%E3%83%87%E3%82%A3%E3%82%B9%E3%83%97%E3%83%AC%E3%82%A4&qid=1621546723&sr=8-1-spons&spLa=ZW5jcnlwdGVkUXVhbGlmaWVyPUEyUlY1Q1JJUFdaSklPJmVuY3J5cHRlZElkPUEwMzgyODA0M0pXSFNLWDk1RlFKTiZlbmNyeXB0ZWRBZElkPUEyVE9VQ1pKNVpYUklMJndpZGdldE5hbWU9c3BfYXRmJmFjdGlvbj1jbGlja1JlZGlyZWN0JmRvTm90TG9nQ2xpY2s9dHJ1ZQ&th=1';
+  var _url;
 
   QuerySnapshot gamanSnapshot;
   List<DocumentSnapshot> documents = [];
@@ -59,6 +59,7 @@ class _HomePageState extends State<HomePage> {
     QuerySnapshot goalSnapshot = await cloud.collection('goals').limit(1).where('userId', isEqualTo: userId).get();
     wantThingPrice = goalSnapshot.docs[0].data()['wantThingPrice'].replaceAll(',', '').replaceAll('￥', '');
     wantThingImg = goalSnapshot.docs[0].data()['wantThingImg'];
+    _url = goalSnapshot.docs[0].data()['wantThingUrl'];
     goalId = goalSnapshot.docs[0].id;
 
     gamanSnapshot = await cloud.collection('gamans').where('goalId', isEqualTo: goalId).orderBy('createdAt', descending: true).get();

--- a/lib/views/home.dart
+++ b/lib/views/home.dart
@@ -28,6 +28,7 @@ class _HomePageState extends State<HomePage> {
   var user = FirebaseAuth.instance.currentUser;
   var cloud = FirebaseFirestore.instance;
   var userEmail;
+  var userId;
   var userName;
   var userPhoto;
   var wantThingPrice;
@@ -51,7 +52,8 @@ class _HomePageState extends State<HomePage> {
     userEmail = user.email;
     userName = user.displayName;
     userPhoto = user.photoURL;
-    QuerySnapshot goalSnapshot = await cloud.collection('goals').limit(1).where('userEmail', isEqualTo: userEmail).get();
+    userId = user.uid;
+    QuerySnapshot goalSnapshot = await cloud.collection('goals').orderBy('createdAt').limit(1).where('userId', isEqualTo: userId).get();
     wantThingPrice = goalSnapshot.docs[0].data()['wantThingPrice'].replaceAll(',', '').replaceAll('￥', '');
     wantThingImg = goalSnapshot.docs[0].data()['wantThingImg'];
     goalId = goalSnapshot.docs[0].id;
@@ -448,7 +450,7 @@ class _HomePageState extends State<HomePage> {
       .collection('gamans')
       .doc()
       .set({
-        'userEmail': userEmail,
+        'userId': userId,
         'userName': userName,
         'userPhotoUrl': userPhoto,
         'price': gamanPrice,
@@ -457,7 +459,7 @@ class _HomePageState extends State<HomePage> {
         'date': date,
         'goalId': goalId, 
       });
-
+    print(userId);
     gamanSnapshot = await FirebaseFirestore.instance.collection('gamans').where('goalId', isEqualTo: goalId).get();
     documents = gamanSnapshot.docs;
 

--- a/lib/views/home.dart
+++ b/lib/views/home.dart
@@ -164,12 +164,12 @@ class _HomePageState extends State<HomePage> {
                     image: AssetImage('image/SliverAppBar2.png'),
                   ),
                 ),
-                padding: EdgeInsets.all(10.0),
+                padding: EdgeInsets.all(8.0),
                 child: SingleChildScrollView(
                   scrollDirection: Axis.horizontal,
                   child: Row(
                     children: <Widget>[
-                      Padding(padding: EdgeInsets.all(5.0)),
+                      Padding(padding: EdgeInsets.all(7.0)),
                       Column(
                         mainAxisAlignment: MainAxisAlignment.end,
                         crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/views/home.dart
+++ b/lib/views/home.dart
@@ -1,6 +1,7 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:my_gaman_app/main.dart';
 import 'package:wave_progress_widget/wave_progress.dart';
 import 'package:intl/intl.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -139,14 +140,27 @@ class _HomePageState extends State<HomePage> {
               title: Text('　目的一覧・変更'),
               onTap: () async {
                 Navigator.of(context).pop();
-                await Navigator.of(context).push(
+                Navigator.of(context).push(
                   MaterialPageRoute(builder: (context) => GoalSelectPage()),
                 );
                 setState(() {
                   setData();
                 });
               },
-            ), 
+            ),
+            ListTile(
+              title: Text(''),
+            ),
+            ListTile(
+              title: Text('　サインアウト'),
+              onTap: () async {
+                await FirebaseAuth.instance.signOut();
+                Navigator.of(context).pop();
+                await Navigator.of(context).pushReplacement(
+                  MaterialPageRoute(builder: (context) => StartPage()),
+                );
+              },
+            ),
           ],
         ),
       ),

--- a/lib/views/home.dart
+++ b/lib/views/home.dart
@@ -441,7 +441,7 @@ class _HomePageState extends State<HomePage> {
 
     final time = DateTime.now();
     final createdAt = Timestamp.fromDate(time);
-    final date = DateTime(time.year, time.month, time.day, time.hour, time.minute);
+    final date = DateFormat('yyyy-MM-dd HH:mm').format(time).toString();
     gamanPrice = priceController.text;
 
     await FirebaseFirestore.instance

--- a/lib/views/home.dart
+++ b/lib/views/home.dart
@@ -55,8 +55,7 @@ class _HomePageState extends State<HomePage> {
     userName = user.displayName;
     userPhoto = user.photoURL;
     userId = user.uid;
-    print(userId);
-    QuerySnapshot goalSnapshot = await cloud.collection('goals').limit(1).where('userId', isEqualTo: userId).get();
+    QuerySnapshot goalSnapshot = await cloud.collection('goals').where('userId', isEqualTo: userId).orderBy('createdAt', descending: true).limit(1).get();
     wantThingPrice = goalSnapshot.docs[0].data()['wantThingPrice'].replaceAll(',', '').replaceAll('￥', '');
     wantThingImg = goalSnapshot.docs[0].data()['wantThingImg'];
     _url = goalSnapshot.docs[0].data()['wantThingUrl'];
@@ -129,6 +128,18 @@ class _HomePageState extends State<HomePage> {
                   user = FirebaseAuth.instance.currentUser;
                   userName = user.displayName;
                   userPhoto = user.photoURL;
+                });
+              },
+            ),
+            ListTile(
+              title: Text('　目的変更'),
+              onTap: () async {
+                Navigator.of(context).pop();
+                await Navigator.of(context).push(
+                  MaterialPageRoute(builder: (context) => SettingPage()),
+                );
+                setState(() {
+                  setData();
                 });
               },
             ), 

--- a/lib/views/home.dart
+++ b/lib/views/home.dart
@@ -53,12 +53,13 @@ class _HomePageState extends State<HomePage> {
     userName = user.displayName;
     userPhoto = user.photoURL;
     userId = user.uid;
-    QuerySnapshot goalSnapshot = await cloud.collection('goals').orderBy('createdAt').limit(1).where('userId', isEqualTo: userId).get();
+    print(userId);
+    QuerySnapshot goalSnapshot = await cloud.collection('goals').limit(1).where('userId', isEqualTo: userId).get();
     wantThingPrice = goalSnapshot.docs[0].data()['wantThingPrice'].replaceAll(',', '').replaceAll('￥', '');
     wantThingImg = goalSnapshot.docs[0].data()['wantThingImg'];
     goalId = goalSnapshot.docs[0].id;
 
-    gamanSnapshot = await cloud.collection('gamans').where('goalId', isEqualTo: goalId).get();
+    gamanSnapshot = await cloud.collection('gamans').where('goalId', isEqualTo: goalId).orderBy('createdAt', descending: true).get();
     documents = gamanSnapshot.docs;
     documents.forEach((document) {
       saving = saving + int.parse(document['price']);
@@ -460,7 +461,7 @@ class _HomePageState extends State<HomePage> {
         'goalId': goalId, 
       });
     print(userId);
-    gamanSnapshot = await FirebaseFirestore.instance.collection('gamans').where('goalId', isEqualTo: goalId).get();
+    gamanSnapshot = await FirebaseFirestore.instance.collection('gamans').where('goalId', isEqualTo: goalId).orderBy('createdAt', descending: true).get();
     documents = gamanSnapshot.docs;
 
     setState(() {

--- a/lib/views/home.dart
+++ b/lib/views/home.dart
@@ -406,10 +406,6 @@ class _HomePageState extends State<HomePage> {
     );
   }
 
-  void _launchURL() async {
-    await canLaunch(_url) ? await launch(_url) : throw 'Could not launch $_url';
-  }
-
   void submitGaman() {
     showModalBottomSheet(
       context: context,
@@ -551,5 +547,36 @@ class _HomePageState extends State<HomePage> {
         },
       );
     }
+  }
+
+  void _launchURL() async {
+    await canLaunch(_url) ? await launch(_url) : errorDialog();
+  }
+
+  void errorDialog() {
+    showDialog(
+      context: context,
+      barrierDismissible: true,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: const Text('エラーが起こりました。'),
+          content: Text('欲しいモノのURLが見つかりません。直接アクセスしてください。'),
+          actions: <Widget>[
+            TextButton(
+              child: const Text('OK'),
+              onPressed: () {
+                Navigator.of(context).pop();
+              },
+            ),
+            TextButton(
+              child: const Text('Cancel'),
+              onPressed: () {
+                Navigator.of(context).pop();
+              },
+            ),
+          ],
+        );
+      },
+    );
   }
 }

--- a/lib/views/home.dart
+++ b/lib/views/home.dart
@@ -7,6 +7,7 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:firebase_storage/firebase_storage.dart' as firebase_storage;
 import 'postview.dart';
 import 'setting.dart';
+import 'goalset.dart';
 import '../configs/colors.dart';
 
 class HomePage extends StatefulWidget {
@@ -85,6 +86,7 @@ class _HomePageState extends State<HomePage> {
     }
 
     return Scaffold(
+      resizeToAvoidBottomInset: false,
       backgroundColor: AppColor.bgColor,
       drawer:Drawer(
         child: ListView(
@@ -136,7 +138,7 @@ class _HomePageState extends State<HomePage> {
               onTap: () async {
                 Navigator.of(context).pop();
                 await Navigator.of(context).push(
-                  MaterialPageRoute(builder: (context) => SettingPage()),
+                  MaterialPageRoute(builder: (context) => GoalSetPage()),
                 );
                 setState(() {
                   setData();
@@ -162,65 +164,68 @@ class _HomePageState extends State<HomePage> {
                     image: AssetImage('image/SliverAppBar2.png'),
                   ),
                 ),
-                padding: EdgeInsets.only(top: 14.0),
-                child: Row(
-                  children: <Widget>[
-                    Padding(padding: EdgeInsets.all(17.0)),
-                    Column(
-                      mainAxisAlignment: MainAxisAlignment.end,
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: <Widget>[
-                        Text(
-                          '目標金額',
-                          style: TextStyle(
-                            color: AppColor.priceColor,
-                            fontSize: 15.0,
-                            fontWeight: FontWeight.w400,
+                padding: EdgeInsets.all(10.0),
+                child: SingleChildScrollView(
+                  scrollDirection: Axis.horizontal,
+                  child: Row(
+                    children: <Widget>[
+                      Padding(padding: EdgeInsets.all(5.0)),
+                      Column(
+                        mainAxisAlignment: MainAxisAlignment.end,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: <Widget>[
+                          Text(
+                            '目標金額',
+                            style: TextStyle(
+                              color: AppColor.priceColor,
+                              fontSize: 15.0,
+                              fontWeight: FontWeight.w400,
+                            ),
                           ),
-                        ),
-                        Row(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          mainAxisSize: MainAxisSize.max,
-                          crossAxisAlignment: CrossAxisAlignment.end,
-                          children: <Widget>[
-                            Text(
-                              formatter.format(int.parse(wantThingPrice)),
-                              style: TextStyle(
-                                color: AppColor.priceColor,
-                                fontSize: 30.0,
-                                fontWeight: FontWeight.w600,
+                          Row(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            mainAxisSize: MainAxisSize.max,
+                            crossAxisAlignment: CrossAxisAlignment.end,
+                            children: <Widget>[
+                              Text(
+                                formatter.format(int.parse(wantThingPrice)),
+                                style: TextStyle(
+                                  color: AppColor.priceColor,
+                                  fontSize: 28.0,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              ),
+                              Text(
+                                '円',
+                                style: TextStyle(
+                                  color: AppColor.priceColor,
+                                  fontSize: 18.0,
+                                  fontWeight: FontWeight.w300,
+                                )
+                              ), 
+                            ],
+                          ),
+                          Padding(padding: EdgeInsets.all(12.0)),
+                        ],
+                      ),
+                      Padding(padding: EdgeInsets.all(4.0)),
+                      Column(
+                        mainAxisAlignment: MainAxisAlignment.end,
+                        children: <Widget>[
+                          Container(
+                            width: 200.0,
+                            height: 200.0,
+                            decoration: BoxDecoration(
+                              image: DecorationImage(
+                                fit: BoxFit.contain,
+                                image: NetworkImage(wantThingImg),
                               ),
                             ),
-                            Text(
-                              '円',
-                              style: TextStyle(
-                                color: AppColor.priceColor,
-                                fontSize: 20.0,
-                                fontWeight: FontWeight.w300,
-                              )
-                            ), 
-                          ],
-                        ),
-                        Padding(padding: EdgeInsets.all(12.0)),
-                      ],
-                    ),
-                    Padding(padding: EdgeInsets.all(7.0)),
-                    Column(
-                      mainAxisAlignment: MainAxisAlignment.end,
-                      children: <Widget>[
-                        Container(
-                          width: 208.0,
-                          height: 200.0,
-                          decoration: BoxDecoration(
-                            image: DecorationImage(
-                              fit: BoxFit.contain,
-                              image: NetworkImage(wantThingImg),
-                            ),
                           ),
-                        ),
-                      ],
-                    ),
-                  ],
+                        ],
+                      ),
+                    ],
+                  ),
                 ),
               ),
             ),
@@ -238,15 +243,15 @@ class _HomePageState extends State<HomePage> {
                       alignment: Alignment.center,
                       children: <Widget>[
                         Container(
-                          width: 320,
-                          height: 320,
+                          width: 310,
+                          height: 310,
                           decoration: BoxDecoration(
                             color: AppColor.white,
                             shape: BoxShape.circle,
                           ),
                         ),
                         WaveProgress(
-                          310.0, AppColor.white, AppColor.wavecolor, _currentValue
+                          300.0, AppColor.white, AppColor.wavecolor, _currentValue
                         ),
                         Container(
                           width: 220,
@@ -265,7 +270,7 @@ class _HomePageState extends State<HomePage> {
                               '現在の貯金額',
                               style: TextStyle(
                                 color: AppColor.priceColor,
-                                fontSize: 18.0,
+                                fontSize: 16.0,
                                 fontWeight: FontWeight.w500,
                               ),
                             ),
@@ -278,7 +283,7 @@ class _HomePageState extends State<HomePage> {
                                   formatter.format(saving),
                                   style: TextStyle(
                                     color: AppColor.priceColor,
-                                    fontSize: 45.0,
+                                    fontSize: 38.0,
                                     fontWeight: FontWeight.w800,
                                   ),
                                 ),
@@ -326,7 +331,7 @@ class _HomePageState extends State<HomePage> {
                                 Text(
                                   document['date'],
                                   style: TextStyle(
-                                    fontSize: 12.0,
+                                    fontSize: 11.0,
                                     fontWeight: FontWeight.w300,
                                   )
                                 ),
@@ -340,7 +345,7 @@ class _HomePageState extends State<HomePage> {
                                   document['text'],
                                   style: TextStyle(
                                     color: AppColor.textColor,
-                                    fontSize: 18.0,
+                                    fontSize: 16.0,
                                     fontWeight: FontWeight.w400,
                                   ),
                                 ),
@@ -350,7 +355,7 @@ class _HomePageState extends State<HomePage> {
                               document['price'],
                               style: TextStyle(
                                 color: AppColor.priceColor,
-                                fontSize: 20.0,
+                                fontSize: 19.0,
                                 fontWeight: FontWeight.w700,
                               ),
                             ),
@@ -369,12 +374,15 @@ class _HomePageState extends State<HomePage> {
         onPressed: () {
           submitGaman();
         },
-        child: Text(
-          '+',
-          style: TextStyle(
-            color: AppColor.white,
-            fontSize: 45.0,
-            fontWeight: FontWeight.w500,
+        child: Container(
+          alignment: Alignment.center,
+          child: Text(
+            '＋',
+            style: TextStyle(
+              color: AppColor.white,
+              fontSize: 40.0,
+              fontWeight: FontWeight.w500,
+            ),
           ),
         ),
         backgroundColor: AppColor.priceColor,

--- a/lib/views/login.dart
+++ b/lib/views/login.dart
@@ -1,6 +1,6 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
-import 'home.dart';
+import 'package:my_gaman_app/views/goalselect.dart';
 import '../configs/colors.dart';
 
 class MyLoginPage extends StatefulWidget {
@@ -61,7 +61,7 @@ class _MyLoginPageState extends State<MyLoginPage> {
 
                     // 登録後Home画面に遷移
                     await Navigator.of(context).pushReplacement(
-                      MaterialPageRoute(builder: (context) => HomePage()),
+                      MaterialPageRoute(builder: (context) => GoalSelectPage()),
                     );
                   } catch (e) {
                     // 登録に失敗した場合

--- a/lib/views/postview.dart
+++ b/lib/views/postview.dart
@@ -76,7 +76,7 @@ class _PostViewPageState extends State<PostViewPage> {
               child: FutureBuilder<QuerySnapshot>(
                 future: FirebaseFirestore.instance
                   .collection('gamans')
-                  .orderBy('createdAt')
+                  .orderBy('createdAt', descending: true)
                   .get(),
                 builder: (context, snapshot) {
                   if (!snapshot.hasData) {
@@ -117,7 +117,7 @@ class _PostViewPageState extends State<PostViewPage> {
                                   ),
                                 ),
                                 Text(
-                                  document['createdAt'],
+                                  document['date'],
                                   style: TextStyle(
                                     fontSize: 9.0,
                                     fontWeight: FontWeight.w300,

--- a/lib/views/postview.dart
+++ b/lib/views/postview.dart
@@ -11,15 +11,9 @@ class PostViewPage extends StatefulWidget {
 
 class _PostViewPageState extends State<PostViewPage> {
 
-  var saving = 0;
-  var gamanPrice;
-
-  TextEditingController priceController = TextEditingController();
-  TextEditingController descriptionController = TextEditingController();
   firebase_storage.FirebaseStorage storage = firebase_storage.FirebaseStorage.instance; 
 
   var user = FirebaseAuth.instance.currentUser;
-  var userEmail;
   var userName;
   var userPhoto;
 
@@ -34,7 +28,6 @@ class _PostViewPageState extends State<PostViewPage> {
   }
 
   void setData() async {
-    userEmail = user.email;
     userName = user.displayName;
     userPhoto = user.photoURL;
 

--- a/lib/views/postview.dart
+++ b/lib/views/postview.dart
@@ -140,8 +140,8 @@ class _PostViewPageState extends State<PostViewPage> {
                                 fontWeight: FontWeight.w700,
                               ),
                             ),
-                          )
-                        )
+                          ),
+                        ),
                       );
                     }).toList(),
                   );

--- a/lib/views/setting.dart
+++ b/lib/views/setting.dart
@@ -15,7 +15,7 @@ class _SettingPageState extends State<SettingPage> {
   TextEditingController userNameController;
 
   var user = FirebaseAuth.instance.currentUser;
-  var userEmail;
+  var userId;
   var userName;
   var userPhoto;
 
@@ -31,7 +31,7 @@ class _SettingPageState extends State<SettingPage> {
   }
 
   void setData() async {
-    userEmail = user.email;
+    userId = user.uid;
     userName = user.displayName;
     userPhoto = user.photoURL;
 
@@ -146,8 +146,8 @@ class _SettingPageState extends State<SettingPage> {
   void uploadImage() async {
     var image = await UploadImage.getImage(true);
     _loading = true;
-    await UploadImage.uploadFile(image, userEmail);
-    userPhoto = await storage.ref('userImages/'+userEmail+'.png').getDownloadURL();
+    await UploadImage.uploadFile(image, userId);
+    userPhoto = await storage.ref('user/'+userId+'/'+userId).getDownloadURL();
     setState(() {
       _loading = false;
     });

--- a/lib/views/signup.dart
+++ b/lib/views/signup.dart
@@ -73,7 +73,7 @@ class _MyAuthPageState extends State<MyAuthPage> {
                     final User user = authResult.user;
 
                     final FirebaseStorage storage = FirebaseStorage.instance;
-                    var photo = storage.ref().child('slime.png').fullPath;
+                    var photo = storage.ref().child('userPhoto.png').fullPath;
                     var photoRef = storage.ref(photo);
                     userPhotoUrl = await getDownloadUrl(photoRef);
                     

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   flutter_hooks: ^0.16.0
   hooks_riverpod: ^0.14.0+3
   provider: ^5.0.0
+  url_launcher: ^6.0.4
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
変更点
---
- 我慢や目的の投稿を、日付順に並べられるように、表示する日付とは別にタイムスタンプを保存
　- 日付降順で投稿を取得できるように。
- セキュリティルールを更新。それに伴いテーブルからUserEmail削除など、微調整。

---
- 欲しいもののURLも保存し、目的達成後にダイアログで通知、商品ページへ遷移できるようにした。
<img width="407" alt="スクリーンショット 2021-05-25 5 47 24" src="https://user-images.githubusercontent.com/44431841/119405725-b0549800-bd1c-11eb-95e3-e4ec72f2fdd3.png">
OKをタップすると、amazonページへ移行する。

---
- 目的一覧表示・追加ができる GoalSelect.dart ページを追加。ここで達成済みの目的にはチェックマークがつく。
　- goalsコレクションのドキュメントに、boolで"achieve"フィールドを追加し、判定。
<img width="392" alt="スクリーンショット 2021-05-25 5 48 23" src="https://user-images.githubusercontent.com/44431841/119405810-d24e1a80-bd1c-11eb-9150-e32da1c212f6.png">
フローティングアクションボタンで、目的を新しく追加できる。
<img width="395" alt="スクリーンショット 2021-05-25 5 48 51" src="https://user-images.githubusercontent.com/44431841/119405852-e2fe9080-bd1c-11eb-9d26-54df3f5823e7.png">
