### PR TITLE
Amazonの画像データを目的設定時にstorageへ保存

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -26,7 +26,7 @@ class MyApp extends StatelessWidget {
         visualDensity: VisualDensity.adaptivePlatformDensity,
         fontFamily: 'Yu Gothic',
       ),
-      home: (user == null) ? StartPage() : GoalSelectPage(),
+      home: (user == null) ? StartPage() : StartPage(),
     );
   }
 }

--- a/lib/models/upload_image.dart
+++ b/lib/models/upload_image.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 import 'package:image_picker/image_picker.dart';
 import 'package:firebase_storage/firebase_storage.dart' as firebase_storage;
+import 'package:http/http.dart' as http;
 
 class UploadImage {
   static PickedFile pickedFile;
@@ -30,8 +31,9 @@ class UploadImage {
   }
 
   static Future<String> uploadAmazonImg(imagePath, userId, date) async {
-    File file = File(imagePath);
-    await storage.ref('user/'+userId+'/'+date).putFile(file);
+    final response = await http.get(Uri.parse(imagePath));
+    print(response);
+    await storage.ref('user/'+userId+'/'+date).putData(response.bodyBytes);
 
     return await storage.ref('user/'+userId+'/'+date).getDownloadURL();
   }

--- a/lib/models/upload_image.dart
+++ b/lib/models/upload_image.dart
@@ -22,8 +22,17 @@ class UploadImage {
     return pickedFile.path;
   }
 
-  static Future<void> uploadFile(imagePath, userId) async {
+  static Future<String> uploadFile(imagePath, userId) async {
     File file = File(imagePath);
     await storage.ref('user/'+userId+'/'+userId).putFile(file);
+
+    return await storage.ref('user/'+userId+'/'+userId).getDownloadURL();
+  }
+
+  static Future<String> uploadAmazonImg(imagePath, userId, date) async {
+    File file = File(imagePath);
+    await storage.ref('user/'+userId+'/'+date).putFile(file);
+
+    return await storage.ref('user/'+userId+'/'+date).getDownloadURL();
   }
 }

--- a/lib/views/goalselect.dart
+++ b/lib/views/goalselect.dart
@@ -5,6 +5,9 @@ import 'package:firebase_storage/firebase_storage.dart' as firebase_storage;
 import 'package:my_gaman_app/views/goalset.dart';
 import '../configs/colors.dart';
 import 'home.dart';
+import 'postview.dart';
+import 'setting.dart';
+import 'package:my_gaman_app/main.dart';
 
 class GoalSelectPage extends StatefulWidget {
   @override
@@ -17,6 +20,7 @@ class _GoalSelectPageState extends State<GoalSelectPage> {
 
   var user = FirebaseAuth.instance.currentUser;
   var userId;
+  var userEmail;
   var userName;
   var userPhoto;
 
@@ -32,6 +36,7 @@ class _GoalSelectPageState extends State<GoalSelectPage> {
 
   void setData() async {
     userId = user.uid;
+    userEmail = user.email;
     userName = user.displayName;
     userPhoto = user.photoURL;
 
@@ -61,6 +66,68 @@ class _GoalSelectPageState extends State<GoalSelectPage> {
         ),
         backgroundColor: AppColor.white,
         shadowColor: AppColor.shadow,
+      ),
+
+      drawer:Drawer(
+        child: ListView(
+          shrinkWrap: true,
+          children: <Widget>[
+            Card(
+              child: ListTile(
+                leading: Container(
+                  height: 65.0,
+                  width: 65.0,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    image: DecorationImage(
+                      fit: BoxFit.fill,
+                      image:NetworkImage(userPhoto),
+                    ),
+                  ),
+                ),
+                title: Text(userName),
+                subtitle: Text(userEmail),
+              )
+            ),
+            Padding(padding: EdgeInsets.all(5.0)),
+            ListTile(
+              title: Text('　タイムライン'),
+              onTap: () {
+                Navigator.of(context).pop();
+                Navigator.of(context).push(
+                  MaterialPageRoute(builder: (context) => PostViewPage()),
+                );
+              },
+            ),
+            ListTile(
+              title: Text('　プロフィール設定'),
+              onTap: () async {
+                Navigator.of(context).pop();
+                await Navigator.of(context).push(
+                  MaterialPageRoute(builder: (context) => SettingPage()),
+                );
+                setState(() {
+                  user = FirebaseAuth.instance.currentUser;
+                  userName = user.displayName;
+                  userPhoto = user.photoURL;
+                });
+              },
+            ),
+            ListTile(
+              title: Text(''),
+            ),
+            ListTile(
+              title: Text('　サインアウト'),
+              onTap: () async {
+                await FirebaseAuth.instance.signOut();
+                Navigator.of(context).pop();
+                await Navigator.of(context).pushReplacement(
+                  MaterialPageRoute(builder: (context) => StartPage()),
+                );
+              },
+            ),
+          ],
+        ),
       ),
 
       body: Container(

--- a/lib/views/goalset.dart
+++ b/lib/views/goalset.dart
@@ -19,9 +19,6 @@ class _GoalSetPageState extends State<GoalSetPage> {
 
   var user = FirebaseAuth.instance.currentUser;
   var userId;
-  var userEmail;
-  var userName;
-  var userPhoto;
 
   bool _loading = true;
 
@@ -30,9 +27,6 @@ class _GoalSetPageState extends State<GoalSetPage> {
     super.initState();
     if (user != null) {
       userId = user.uid;
-      userEmail = user.email;
-      userName = user.displayName;
-      userPhoto = user.photoURL;
     }
     setState(() {
       _loading = false;
@@ -88,6 +82,14 @@ class _GoalSetPageState extends State<GoalSetPage> {
                 '欲しいもの',
                 style: TextStyle(
                   fontSize: 16.0,
+                  fontWeight: FontWeight.w500,
+                  color: AppColor.shadow,
+                ),
+              ),
+              Text(
+                '※ Amazon商品リンクを貼り付けてください.（セール商品は対象外です.）',
+                style: TextStyle(
+                  fontSize: 10.0,
                   fontWeight: FontWeight.w500,
                   color: AppColor.shadow,
                 ),
@@ -150,8 +152,6 @@ class _GoalSetPageState extends State<GoalSetPage> {
       .doc()
       .set({
         'userId': userId,
-        'userName': userName,
-        'userPhotoUrl': userPhoto,
         'goalText': goalTextController.text,
         'wantThingUrl': wantThingController.text,
         'wantThingImg': wantThingImg,

--- a/lib/views/goalset.dart
+++ b/lib/views/goalset.dart
@@ -4,6 +4,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:intl/intl.dart';
 import 'package:my_gaman_app/views/goalselect.dart';
 import 'package:universal_html/controller.dart';
+import '../models/upload_image.dart';
 import '../configs/colors.dart';
 
 class GoalSetPage extends StatefulWidget {
@@ -139,8 +140,10 @@ class _GoalSetPageState extends State<GoalSetPage> {
       uri: Uri.parse(wantThingController.text),
     );
     final imgContainer = controller.window.document.querySelector("#imgTagWrapperId");
-    final wantThingImg = imgContainer.querySelectorAll("img").first.getAttribute("src");
+    final wantThingAmazonImg = imgContainer.querySelectorAll("img").first.getAttribute("src");
     final wantThingPrice = controller.window.document.querySelectorAll("span.priceBlockBuyingPriceString").first.text;
+    
+    final wantThingImg = UploadImage.uploadAmazonImg(wantThingAmazonImg, userId, date);
 
     await FirebaseFirestore.instance
       .collection('goals')

--- a/lib/views/goalset.dart
+++ b/lib/views/goalset.dart
@@ -143,7 +143,7 @@ class _GoalSetPageState extends State<GoalSetPage> {
     final wantThingAmazonImg = imgContainer.querySelectorAll("img").first.getAttribute("src");
     final wantThingPrice = controller.window.document.querySelectorAll("span.priceBlockBuyingPriceString").first.text;
     
-    final wantThingImg = UploadImage.uploadAmazonImg(wantThingAmazonImg, userId, date);
+    final wantThingImg = await UploadImage.uploadAmazonImg(wantThingAmazonImg, userId, date);
 
     await FirebaseFirestore.instance
       .collection('goals')

--- a/lib/views/home.dart
+++ b/lib/views/home.dart
@@ -491,16 +491,13 @@ class _HomePageState extends State<HomePage> {
       .doc()
       .set({
         'userId': userId,
-        'userName': userName,
-        'userPhotoUrl': userPhoto,
         'price': gamanPrice,
         'text': descriptionController.text,
         'createdAt': createdAt,
         'date': date,
         'goalId': goalId, 
       });
-    print(userId);
-    gamanSnapshot = await FirebaseFirestore.instance.collection('gamans').where('goalId', isEqualTo: goalId).orderBy('createdAt', descending: true).get();
+    gamanSnapshot = await cloud.collection('gamans').where('goalId', isEqualTo: goalId).orderBy('createdAt', descending: true).get();
     documents = gamanSnapshot.docs;
 
     setState(() {

--- a/lib/views/login.dart
+++ b/lib/views/login.dart
@@ -66,7 +66,7 @@ class _MyLoginPageState extends State<MyLoginPage> {
                   } catch (e) {
                     // 登録に失敗した場合
                     setState(() {
-                      infoText = "登録NG：{e.message}";
+                      infoText = "認証NG：{e.message}";
                     });
                   }
                 },

--- a/lib/views/mailcheck.dart
+++ b/lib/views/mailcheck.dart
@@ -24,7 +24,6 @@ class _Emailcheck extends State<Emailcheck> {
   Widget build(BuildContext context) {
 
     _sentEmailText = '${widget.email}\nに確認メールを送信しました。';
-    _nocheckText = '';
 
     return Scaffold(
       // メイン画面
@@ -34,7 +33,8 @@ class _Emailcheck extends State<Emailcheck> {
           children: [
             Padding(
               padding: EdgeInsets.fromLTRB(20.0, 0, 20.0, 20.0),
-              child: Text(_nocheckText,
+              child: Text(
+                _nocheckText,
                 style: TextStyle(color: Colors.red),
               ),
             ),
@@ -64,8 +64,10 @@ class _Emailcheck extends State<Emailcheck> {
                   },
 
                   // ボタン内の文字や書式
-                  child: Text('確認メールを再送信',
-                    style: TextStyle(fontWeight: FontWeight.bold),),
+                  child: Text(
+                    '確認メールを再送信',
+                    style: TextStyle(fontWeight: FontWeight.bold),
+                  ),
                   textColor: AppColor.white,
                   color: AppColor.shadow,
                 ),
@@ -88,7 +90,7 @@ class _Emailcheck extends State<Emailcheck> {
                     email: widget.email,
                     password: widget.pswd,
                   );
-                  final _verify = await authResult.user.emailVerified; 
+                  final _verify = authResult.user.emailVerified; 
                   // Email確認が済んでいる場合は、Home画面へ遷移
                   if (_verify){
                     Navigator.push(
@@ -97,10 +99,10 @@ class _Emailcheck extends State<Emailcheck> {
                         builder: (context) => MyLoginPage(),
                       )
                     );
-                  }else{
+                  } else {
                     // print('NG');
                     setState(() {
-                      _nocheckText = "まだメール確認が完了していません。確認メール内のリンクをクリックしてください。";
+                      _nocheckText = "まだメール確認が完了していません。\n確認メール内のリンクをクリックしてください。";
                     });
                   }
                 },

--- a/lib/views/mailcheck.dart
+++ b/lib/views/mailcheck.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import '../configs/colors.dart';
+import 'login.dart';
+
+
+class Emailcheck extends StatefulWidget {
+   // 呼び出し元Widgetから受け取った後、変更をしないためfinalを宣言。
+  final String email;
+  final String pswd;
+  Emailcheck({Key key, this.email, this.pswd}) : super(key: key);
+
+  @override
+  _Emailcheck createState() => _Emailcheck();
+}
+
+
+class _Emailcheck extends State<Emailcheck> {
+  final auth = FirebaseAuth.instance;
+  String _sentEmailText;
+  String _nocheckText;
+
+  @override
+  Widget build(BuildContext context) {
+
+    _sentEmailText = '${widget.email}\nに確認メールを送信しました。';
+    _nocheckText = '';
+
+    return Scaffold(
+      // メイン画面
+      body:Center(
+        child:Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Padding(
+              padding: EdgeInsets.fromLTRB(20.0, 0, 20.0, 20.0),
+              child: Text(_nocheckText,
+                style: TextStyle(color: Colors.red),
+              ),
+            ),
+
+            // 確認メール送信時のメッセージ
+            Text(_sentEmailText),
+
+            // 確認メールの再送信ボタン
+            Padding(
+              padding: EdgeInsets.fromLTRB(0, 0, 0, 30.0),
+              child:ButtonTheme(
+                minWidth: 200.0,  
+                // height: 100.0,
+                child: RaisedButton(
+                  // ボタンの形状
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+
+                  onPressed: () async {
+                    final UserCredential authResult = await auth.signInWithEmailAndPassword(
+                      email: widget.email,
+                      password: widget.pswd,
+                    );
+
+                    await authResult.user.sendEmailVerification();
+                  },
+
+                  // ボタン内の文字や書式
+                  child: Text('確認メールを再送信',
+                    style: TextStyle(fontWeight: FontWeight.bold),),
+                  textColor: AppColor.white,
+                  color: AppColor.shadow,
+                ),
+              ),
+            ),
+
+            // メール確認完了のボタン配置（Home画面に遷移）
+            ButtonTheme(
+              minWidth: 350.0,  
+              // height: 100.0,
+              child: RaisedButton(
+
+                // ボタンの形状
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(10),
+                ),
+
+                onPressed: () async {
+                  final UserCredential authResult = await auth.signInWithEmailAndPassword(
+                    email: widget.email,
+                    password: widget.pswd,
+                  );
+                  final _verify = await authResult.user.emailVerified; 
+                  // Email確認が済んでいる場合は、Home画面へ遷移
+                  if (_verify){
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) => MyLoginPage(),
+                      )
+                    );
+                  }else{
+                    // print('NG');
+                    setState(() {
+                      _nocheckText = "まだメール確認が完了していません。確認メール内のリンクをクリックしてください。";
+                    });
+                  }
+                },
+                // ボタン内の文字や書式
+                child: Text('メール確認完了',
+                  style: TextStyle(fontWeight: FontWeight.bold),),
+                textColor: AppColor.white,
+                color: AppColor.wavecolor,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/postview.dart
+++ b/lib/views/postview.dart
@@ -11,8 +11,9 @@ class PostViewPage extends StatefulWidget {
 
 class _PostViewPageState extends State<PostViewPage> {
 
-  firebase_storage.FirebaseStorage storage = firebase_storage.FirebaseStorage.instance; 
+  firebase_storage.FirebaseStorage storage = firebase_storage.FirebaseStorage.instance;
 
+  var cloud = FirebaseFirestore.instance;
   var user = FirebaseAuth.instance.currentUser;
   var userName;
   var userPhoto;
@@ -67,7 +68,7 @@ class _PostViewPageState extends State<PostViewPage> {
           children: <Widget>[
             Expanded(
               child: FutureBuilder<QuerySnapshot>(
-                future: FirebaseFirestore.instance
+                future: cloud
                   .collection('gamans')
                   .orderBy('createdAt', descending: true)
                   .get(),
@@ -87,59 +88,73 @@ class _PostViewPageState extends State<PostViewPage> {
                         elevation: 2.0,
                         child: Padding(
                           padding: EdgeInsets.all(7.0),
-                          child: ListTile(
-                            leading: Container(
-                              height: 55.0,
-                              width: 55.0,
-                              decoration: BoxDecoration(
-                                borderRadius: BorderRadius.circular(8.0),
-                                image: DecorationImage(
-                                  image: NetworkImage(document['userPhotoUrl']),
-                                  fit: BoxFit.cover,
+                          child: FutureBuilder<DocumentSnapshot>(
+                            future: cloud
+                              .collection('users')
+                              .doc(document['userId'])
+                              .get(),
+                            builder: (context, snapshot) {
+                              if (!snapshot.hasData) {
+                                return Center(
+                                  child: CircularProgressIndicator()
+                                );
+                              }
+                              final DocumentSnapshot userData = snapshot.data;
+                              return ListTile(
+                                leading: Container(
+                                  height: 55.0,
+                                  width: 55.0,
+                                  decoration: BoxDecoration(
+                                    borderRadius: BorderRadius.circular(8.0),
+                                    image: DecorationImage(
+                                      image: NetworkImage(userData['userPhotoUrl']),
+                                      fit: BoxFit.cover,
+                                    ),
+                                  ),
                                 ),
-                              ),
-                            ),
-                            title: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: <Widget>[
-                                Text(
-                                  document['userName'],
+                                title: Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: <Widget>[
+                                    Text(
+                                      userData['userName'],
+                                      style: TextStyle(
+                                        fontSize: 16.0,
+                                        fontWeight: FontWeight.w700,
+                                      ),
+                                    ),
+                                    Text(
+                                      document['date'],
+                                      style: TextStyle(
+                                        fontSize: 9.0,
+                                        fontWeight: FontWeight.w300,
+                                      )
+                                    ),
+                                  ],
+                                ),
+                                subtitle: Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: <Widget>[
+                                    Padding(padding: EdgeInsets.all(3.0)),
+                                    Text(
+                                      document['text'],
+                                      style: TextStyle(
+                                        color: AppColor.textColor,
+                                        fontSize: 15.0,
+                                        fontWeight: FontWeight.w400,
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                                trailing: Text(
+                                  document['price'],
                                   style: TextStyle(
-                                    fontSize: 16.0,
+                                    color: AppColor.priceColor,
+                                    fontSize: 20.0,
                                     fontWeight: FontWeight.w700,
                                   ),
                                 ),
-                                Text(
-                                  document['date'],
-                                  style: TextStyle(
-                                    fontSize: 9.0,
-                                    fontWeight: FontWeight.w300,
-                                  )
-                                ),
-                              ],
-                            ),
-                            subtitle: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: <Widget>[
-                                Padding(padding: EdgeInsets.all(3.0)),
-                                Text(
-                                  document['text'],
-                                  style: TextStyle(
-                                    color: AppColor.textColor,
-                                    fontSize: 15.0,
-                                    fontWeight: FontWeight.w400,
-                                  ),
-                                ),
-                              ],
-                            ),
-                            trailing: Text(
-                              document['price'],
-                              style: TextStyle(
-                                color: AppColor.priceColor,
-                                fontSize: 20.0,
-                                fontWeight: FontWeight.w700,
-                              ),
-                            ),
+                              );
+                            },
                           ),
                         ),
                       );

--- a/lib/views/setting.dart
+++ b/lib/views/setting.dart
@@ -1,6 +1,5 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
-import 'package:firebase_storage/firebase_storage.dart' as firebase_storage;
 import '../configs/colors.dart';
 import '../models/upload_image.dart';
 
@@ -11,7 +10,6 @@ class SettingPage extends StatefulWidget {
 
 class _SettingPageState extends State<SettingPage> {
 
-  firebase_storage.FirebaseStorage storage = firebase_storage.FirebaseStorage.instance; 
   TextEditingController userNameController;
 
   var user = FirebaseAuth.instance.currentUser;
@@ -146,8 +144,7 @@ class _SettingPageState extends State<SettingPage> {
   void uploadImage() async {
     var image = await UploadImage.getImage(true);
     _loading = true;
-    await UploadImage.uploadFile(image, userId);
-    userPhoto = await storage.ref('user/'+userId+'/'+userId).getDownloadURL();
+    userPhoto = await UploadImage.uploadFile(image, userId);
     setState(() {
       _loading = false;
     });

--- a/lib/views/setting.dart
+++ b/lib/views/setting.dart
@@ -1,4 +1,5 @@
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import '../configs/colors.dart';
 import '../models/upload_image.dart';
@@ -12,6 +13,7 @@ class _SettingPageState extends State<SettingPage> {
 
   TextEditingController userNameController;
 
+  var cloud = FirebaseFirestore.instance;
   var user = FirebaseAuth.instance.currentUser;
   var userId;
   var userName;
@@ -153,6 +155,14 @@ class _SettingPageState extends State<SettingPage> {
   void saveUsers() async {
     await user.updateProfile(displayName: userNameController.text, photoURL: userPhoto);
     await user.reload();
+
+    await cloud
+      .collection('users')
+      .doc(userId)
+      .update({
+        'userName': userNameController.text,
+        'userPhotoUrl': userPhoto,
+      });
     Navigator.of(context).pop();
   }
 }

--- a/lib/views/signup.dart
+++ b/lib/views/signup.dart
@@ -2,7 +2,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_storage/firebase_storage.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
-import 'goalset.dart';
+import 'mailcheck.dart';
 import '../configs/colors.dart';
 
 class MyAuthPage extends StatefulWidget {
@@ -71,6 +71,8 @@ class _MyAuthPageState extends State<MyAuthPage> {
                       email: newUserEmail, password: newUserPassword,
                     );
 
+                    await auth.currentUser.sendEmailVerification();
+
                     final User user = authResult.user;
 
                     final time = DateTime.now();
@@ -93,10 +95,11 @@ class _MyAuthPageState extends State<MyAuthPage> {
                         'userPhotoUrl': userPhotoUrl,
                         'createdAt' : createdAt,
                       });
+                    
 
                     // 登録後Home画面に遷移
                     await Navigator.of(context).pushReplacement(
-                      MaterialPageRoute(builder: (context) => GoalSetPage()),
+                      MaterialPageRoute(builder: (context) => Emailcheck(email: newUserEmail, pswd: newUserPassword,)),
                     );
                   } catch (e) {
                     // 登録に失敗した場合

--- a/lib/views/signup.dart
+++ b/lib/views/signup.dart
@@ -1,5 +1,6 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_storage/firebase_storage.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'goalset.dart';
 import '../configs/colors.dart';
@@ -72,6 +73,9 @@ class _MyAuthPageState extends State<MyAuthPage> {
 
                     final User user = authResult.user;
 
+                    final time = DateTime.now();
+                    final createdAt = Timestamp.fromDate(time);
+
                     final FirebaseStorage storage = FirebaseStorage.instance;
                     var photo = storage.ref().child('userPhoto.png').fullPath;
                     var photoRef = storage.ref(photo);
@@ -79,6 +83,16 @@ class _MyAuthPageState extends State<MyAuthPage> {
                     
                     await user.updateProfile(displayName: userName, photoURL: userPhotoUrl);
                     await user.reload();
+
+                    await FirebaseFirestore.instance
+                      .collection('users')
+                      .doc(user.uid)
+                      .set({
+                        'userId': user.uid,
+                        'userName': userName,
+                        'userPhotoUrl': userPhotoUrl,
+                        'createdAt' : createdAt,
+                      });
 
                     // 登録後Home画面に遷移
                     await Navigator.of(context).pushReplacement(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   hooks_riverpod: ^0.14.0+3
   provider: ^5.0.0
   url_launcher: ^6.0.4
+  http: ^0.13.3
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
変更点
---
- Amazonの画像データを目的設定時にstorageへ保存するように変更
<img width="378" alt="スクリーンショット 2021-05-28 18 09 20" src="https://user-images.githubusercontent.com/44431841/119960395-df4e6080-bfdf-11eb-93b2-666fd22d9d93.png">
問題なく動作
---
- ユーザーデータをUsersコレクションに追加し、そこからタイムライン表示時にユーザー情報を取得するように変更。
<img width="386" alt="スクリーンショット 2021-05-28 18 10 06" src="https://user-images.githubusercontent.com/44431841/119960446-f0976d00-bfdf-11eb-83ad-bfae94f72cce.png">
問題なく動作

---
- サインアップ時にメアド認証するように修正。メアド確認画面を追加。
<img width="388" alt="スクリーンショット 2021-05-28 18 11 42" src="https://user-images.githubusercontent.com/44431841/119960670-29cfdd00-bfe0-11eb-8aa6-8e8ce396bb5d.png">
<img width="865" alt="スクリーンショット 2021-05-28 18 12 09" src="https://user-images.githubusercontent.com/44431841/119960722-3a805300-bfe0-11eb-8b42-da84af938d8c.png">
<img width="353" alt="スクリーンショット 2021-05-28 18 12 30" src="https://user-images.githubusercontent.com/44431841/119960761-4704ab80-bfe0-11eb-9d23-3ee4a4dfd371.png">

ブランチ：Yamamoto/make user data savewant img