### PR TITLE
Firebaseのメッセージを日本語化するクラスを追加

### DIFF
--- a/lib/models/firebase_error.dart
+++ b/lib/models/firebase_error.dart
@@ -1,0 +1,93 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+
+enum FirebaseAuthResultStatus {
+  Successful,
+  EmailAlreadyExists,
+  WrongPassword,
+  InvalidEmail,
+  UserNotFound,
+  UserDisabled,
+  OperationNotAllowed,
+  TooManyRequests,
+  Undefined,
+}
+
+class FirebaseAuthExceptionHandler {
+
+  static FirebaseAuthResultStatus handleException(FirebaseAuthException e) {
+    FirebaseAuthResultStatus result;
+    switch (e.code) {
+      case 'invalid-email':
+        result = FirebaseAuthResultStatus.InvalidEmail;
+        break;
+
+      case 'wrong-password':
+        result = FirebaseAuthResultStatus.WrongPassword;
+        break;
+
+      case 'user-not-found':
+        result = FirebaseAuthResultStatus.UserNotFound;
+        break;
+
+      case 'user-disabled':
+        result = FirebaseAuthResultStatus.UserDisabled;
+        break;
+
+      case 'too-many-requests':
+        result = FirebaseAuthResultStatus.TooManyRequests;
+        break;
+
+      case 'operation-not-allowed':
+        result = FirebaseAuthResultStatus.OperationNotAllowed;
+        break;
+
+      case 'email-already-in-use':
+        result = FirebaseAuthResultStatus.EmailAlreadyExists;
+        break;
+
+      default:
+        result = FirebaseAuthResultStatus.Undefined;
+        break;
+    }
+    return result;
+  }
+
+  static String exceptionMessage(FirebaseAuthResultStatus result) {
+    String message = '';
+    switch (result) {
+      case FirebaseAuthResultStatus.InvalidEmail:
+        message = 'メールアドレスが間違っています。';
+        break;
+
+      case FirebaseAuthResultStatus.WrongPassword:
+        message = 'パスワードが間違っています。';
+        break;
+
+      case FirebaseAuthResultStatus.UserNotFound:
+        message = 'このアカウントは存在しません。';
+        break;
+
+      case FirebaseAuthResultStatus.UserDisabled:
+        message = 'このメールアドレスは無効になっています。';
+        break;
+
+      case FirebaseAuthResultStatus.TooManyRequests:
+        message = '回線が混雑しています。もう一度試してみてください。';
+        break;
+
+      case FirebaseAuthResultStatus.OperationNotAllowed:
+        message = 'メールアドレスとパスワードでのログインは有効になっていません。';
+        break;
+
+      case FirebaseAuthResultStatus.EmailAlreadyExists:
+        message = 'このメールアドレスはすでに登録されています。';
+        break;
+
+      default:
+        message = '予期せぬエラーが発生しました。';
+        break;
+    }
+    return message;
+  }
+}

--- a/lib/views/goalset.dart
+++ b/lib/views/goalset.dart
@@ -83,6 +83,7 @@ class _GoalSetPageState extends State<GoalSetPage> {
                         fontSize: 18.0,
                         fontWeight: FontWeight.w400,
                       ),
+                      maxLength: 15,
                     ),
                     Visibility(
                       visible: isGoalEmpty,

--- a/lib/views/goalset_manual.dart
+++ b/lib/views/goalset_manual.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/services.dart';
 import 'package:intl/intl.dart';
 import 'package:my_gaman_app/views/goalselect.dart';
 import '../models/upload_image.dart';
@@ -85,6 +86,7 @@ class _GoalSetManualPageState extends State<GoalSetManualPage> {
                         fontSize: 18.0,
                         fontWeight: FontWeight.w400,
                       ),
+                      maxLength: 15,
                     ),
                     Visibility(
                       visible: isGoalEmpty,
@@ -109,6 +111,8 @@ class _GoalSetManualPageState extends State<GoalSetManualPage> {
                         fontSize: 18.0,
                         fontWeight: FontWeight.w400,
                       ),
+                      maxLength: 7,
+                      inputFormatters: [FilteringTextInputFormatter.digitsOnly],
                     ),
                     Visibility(
                       visible: isPriceEmpty,

--- a/lib/views/home.dart
+++ b/lib/views/home.dart
@@ -1,6 +1,7 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/services.dart';
 import 'package:my_gaman_app/main.dart';
 import 'package:wave_progress_widget/wave_progress.dart';
 import 'package:intl/intl.dart';
@@ -430,13 +431,15 @@ class _HomePageState extends State<HomePage> {
                 color: AppColor.shadow,
               ),
             ),
-            TextField(
+            TextFormField(
               controller: priceController,
               style: TextStyle(
                 fontSize: 20.0,
                 fontWeight: FontWeight.w400,
               ),
               keyboardType: TextInputType.number,
+              inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+              maxLength: 6,
             ),
             SizedBox(height: 40.0),
             Text(
@@ -453,6 +456,7 @@ class _HomePageState extends State<HomePage> {
                 fontSize: 20.0,
                 fontWeight: FontWeight.w400,
               ),
+              maxLength: 15,
             ),
             Padding(padding: EdgeInsets.all(60.0),),
             Container(

--- a/lib/views/home.dart
+++ b/lib/views/home.dart
@@ -537,14 +537,14 @@ class _HomePageState extends State<HomePage> {
               ),
               actions: <Widget>[
                 TextButton(
-                  child: const Text('OK'),
-                  onPressed: _launchURL,
-                ),
-                TextButton(
                   child: const Text('Cancel'),
                   onPressed: () {
                     Navigator.of(context).pop();
                   },
+                ),
+                TextButton(
+                  child: const Text('OK'),
+                  onPressed: _launchURL,
                 ),
               ],
             );
@@ -572,13 +572,13 @@ class _HomePageState extends State<HomePage> {
           content: Text('欲しいモノのURLが見つかりません。直接アクセスしてください。'),
           actions: <Widget>[
             TextButton(
-              child: const Text('OK'),
+              child: const Text('Cancel'),
               onPressed: () {
                 Navigator.of(context).pop();
               },
             ),
             TextButton(
-              child: const Text('Cancel'),
+              child: const Text('OK'),
               onPressed: () {
                 Navigator.of(context).pop();
               },

--- a/lib/views/login.dart
+++ b/lib/views/login.dart
@@ -1,8 +1,8 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:my_gaman_app/views/goalselect.dart';
 import '../configs/colors.dart';
+import '../models/firebase_error.dart';
 import 'mailcheck.dart';
 
 class MyLoginPage extends StatefulWidget {
@@ -91,15 +91,15 @@ class _MyLoginPageState extends State<MyLoginPage> {
                                 MaterialPageRoute(builder: (context) => Emailcheck(email: user.email)),
                               );
                             }
-                          } on PlatformException catch (error) {
+                          } on FirebaseAuthException catch (error) {
                             // 登録に失敗した場合
                             setState(() {
-                              infoText = "登録NG：${error.message}";
+                              infoText = FirebaseAuthExceptionHandler.exceptionMessage(FirebaseAuthExceptionHandler.handleException(error));
                             });
                           } on Exception catch (e) {
                             // 登録に失敗した場合
                             setState(() {
-                              infoText = "登録NG: $e";
+                              infoText = "認証NG: $e";
                             });
                           }
                         } else {
@@ -115,7 +115,10 @@ class _MyLoginPageState extends State<MyLoginPage> {
                         onPrimary: AppColor.textColor,
                       ),
                     ),
-                    Text(infoText)
+                    Text(
+                      infoText,
+                      style: TextStyle(color: Colors.red),
+                    ),
                   ],
                 ),
               ),

--- a/lib/views/setting.dart
+++ b/lib/views/setting.dart
@@ -159,6 +159,12 @@ class _SettingPageState extends State<SettingPage> {
                         ),
                         actions: <Widget>[
                           TextButton(
+                            child: const Text('Cancel'),
+                            onPressed: () {
+                              Navigator.of(context).pop();
+                            },
+                          ),
+                          TextButton(
                             child: const Text('OK'),
                             onPressed: deleteUser,
                           ),


### PR DESCRIPTION
変更点
---
- Firebaseのエラーメッセージを日本語化。
- エラーが解消されるとエラーメッセージが消えるように修正。
- 文字数制限、数字制限が必要なフィールドにはそれを追加。
- アカウント削除ダイアログでキャンセルボタンを追加。