### PR TITLE
正規表現でアマゾンのURLを抜き取れるように。

### DIFF
--- a/lib/views/goalset.dart
+++ b/lib/views/goalset.dart
@@ -185,9 +185,10 @@ class _GoalSetPageState extends State<GoalSetPage> {
       final date = DateFormat('yyyy-MM-dd HH:mm').format(time).toString();
 
       try {
+        final amazonUrl = getAmazonlink(wantThingController.text);
         final controller = WindowController();
         await controller.openHttp(
-          uri: Uri.parse(wantThingController.text),
+          uri: Uri.parse(amazonUrl),
         );
         final imgContainer = controller.window.document.querySelector("#imgTagWrapperId");
         final wantThingAmazonImg = imgContainer.querySelectorAll("img").first.getAttribute("src");
@@ -201,7 +202,7 @@ class _GoalSetPageState extends State<GoalSetPage> {
           .set({
             'userId': userId,
             'goalText': goalTextController.text,
-            'wantThingUrl': wantThingController.text,
+            'wantThingUrl': amazonUrl,
             'wantThingImg': wantThingImg,
             'wantThingPrice': wantThingPrice,
             'createdAt' : createdAt,
@@ -253,5 +254,20 @@ class _GoalSetPageState extends State<GoalSetPage> {
         isWantThingEmpty = wantThingController.text.isEmpty;
       });
     }
+  }
+
+  String getAmazonlink (String input){
+    final List<String> amazonUrl = <String>[];
+    // RegExpを定義
+    final RegExp urlRegExp = RegExp(
+      r'((https?:www\.)|(https?:\/\/)|(www\.))[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9]{1,6}(\/[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)?'
+    );
+          
+    // ここで、Iterable型でURLの配列を取得
+    final Iterable<RegExpMatch> urlMatches = urlRegExp.allMatches(input);
+    for (RegExpMatch urlMatch in urlMatches) {
+      return input.substring(urlMatch.start, urlMatch.end);
+    }
+    return null;
   }
 }


### PR DESCRIPTION
変更点
---
シェアなどの機能により、文字が紛れていてもAmazonのURLを抜き取れるように、正規表現を利用して実装した。
なお、URLの短縮については、シェアか、Webからのコピペかで該当要素の位置が変わるのと、ユーザーにURLが見えるわけではない。などの理由から、短縮は行わず実装した。