### PR TITLE
リリースのためのブラッシュアップ３

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -40,7 +40,7 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.my_gaman_app"
-        minSdkVersion 23
+        minSdkVersion 24
         targetSdkVersion 29
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/lib/models/upload_image.dart
+++ b/lib/models/upload_image.dart
@@ -34,7 +34,6 @@ class UploadImage {
 
   static Future<String> uploadAmazonImg(imagePath, userId, date) async {
     final response = await http.get(Uri.parse(imagePath));
-    print(response);
     await storage.ref('user/'+userId+'/'+date).putData(response.bodyBytes);
 
     return await storage.ref('user/'+userId+'/'+date).getDownloadURL();

--- a/lib/models/upload_image.dart
+++ b/lib/models/upload_image.dart
@@ -20,7 +20,9 @@ class UploadImage {
         source: ImageSource.camera,);
     }
 
-    return pickedFile.path;
+    if (pickedFile != null) {
+      return pickedFile.path;
+    }
   }
 
   static Future<String> uploadFile(imagePath, userId) async {

--- a/lib/views/delete.dart
+++ b/lib/views/delete.dart
@@ -126,7 +126,7 @@ class _DeleteLoginPageState extends State<DeleteLoginPage> {
                                 
                                 await auth.currentUser.delete();
 
-                                await Navigator.of(context).pushAndRemoveUntil(
+                                Navigator.of(context).pushAndRemoveUntil(
                                   MaterialPageRoute(builder: (context) => StartPage()),
                                   (_) => false
                                 );

--- a/lib/views/delete.dart
+++ b/lib/views/delete.dart
@@ -1,0 +1,177 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_storage/firebase_storage.dart' as firebase_storage;
+import 'package:flutter/material.dart';
+import 'package:my_gaman_app/views/reset_password.dart';
+import 'package:my_gaman_app/views/show_progress.dart';
+import '../configs/colors.dart';
+import '../main.dart';
+import '../models/firebase_error.dart';
+
+class DeleteLoginPage extends StatefulWidget {
+  @override
+  _DeleteLoginPageState createState() => _DeleteLoginPageState();
+}
+
+class _DeleteLoginPageState extends State<DeleteLoginPage> {
+  TextEditingController emailController = TextEditingController();
+  TextEditingController passController = TextEditingController();
+  String infoText = "";
+  var cloud = FirebaseFirestore.instance;
+  var isEmailEmpty = false;
+  var isPassEmpty = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        iconTheme: IconThemeData(color: Colors.grey),
+        title: Text(
+          'アカウント削除',
+          style: TextStyle(color: Colors.black),
+        ),
+        backgroundColor: AppColor.white,
+      ),
+      body: GestureDetector(
+        onTap: () {
+          FocusScope.of(context).unfocus();
+        },
+        child: LayoutBuilder(
+          builder: (context, constraints) => SingleChildScrollView(
+            physics: AlwaysScrollableScrollPhysics(),
+            child: ConstrainedBox(
+              constraints: BoxConstraints(minHeight: constraints.maxHeight),
+              child: Center(
+                child: Container(
+                  padding: EdgeInsets.all(32.0),
+                  child: Column(
+                    children: <Widget>[
+                      TextFormField(
+                        decoration: InputDecoration(labelText: "メールアドレス"),
+                        controller: emailController,
+                      ),
+                      Visibility(
+                        visible: isEmailEmpty,
+                        child: Text(
+                          "アカウントのメールアドレスを入力してください。",
+                          style: TextStyle(color: Colors.red),
+                        ),
+                      ),
+                      TextFormField(
+                        decoration: InputDecoration(labelText: "パスワード"),
+                        //　パスワードを見えないように
+                        obscureText: true,
+                        controller: passController,
+                      ),
+                      Visibility(
+                        visible: isPassEmpty,
+                        child: Text(
+                          "パスワードを入力してください。",
+                          style: TextStyle(color: Colors.red),
+                        ),
+                      ),
+                      SizedBox(height: 10),
+                      Align(
+                        alignment: Alignment.bottomRight,
+                        child: InkWell (
+                          child: Text(
+                            'パスワードを忘れましたか？',
+                            style: TextStyle(color: AppColor.priceColor),
+                          ),
+                          onTap: () {
+                            Navigator.of(context).pushReplacement(
+                              MaterialPageRoute(builder: (context) => ResetPassPage()),
+                            );
+                          },
+                        ),
+                      ),
+                      Padding(padding: EdgeInsets.all(30.0)),
+                      ElevatedButton(
+                        onPressed: () async {
+                          if (emailController.text.isNotEmpty && passController.text.isNotEmpty) {
+                            try {
+                              ShowProgress.showProgressDialog(context);
+
+                              final FirebaseAuth auth = FirebaseAuth.instance;
+                              final currentUser = auth.currentUser;
+
+                              if (currentUser.email == emailController.text) {
+                                final UserCredential authResult = await auth.signInWithEmailAndPassword(
+                                  email: emailController.text, password: passController.text,
+                                );
+                                final userId = authResult.user.uid;
+                                final gamans = await cloud.collection('gamans').where('userId', isEqualTo: userId).get();
+                                final gamandocs = gamans.docs;
+                                gamandocs.forEach((gamandoc) async {
+                                  await cloud.collection('gamans').doc(gamandoc.id).delete();
+                                });
+
+                                final goals = await cloud.collection('goals').where('userId', isEqualTo: userId).get();
+                                final goaldocs = goals.docs;
+                                goaldocs.forEach((goaldoc) async {
+                                  await cloud.collection('goals').doc(goaldoc.id).delete();
+                                });
+
+                                firebase_storage.ListResult result = await firebase_storage.FirebaseStorage.instance.ref('user/'+userId).listAll();
+                                result.items.forEach((firebase_storage.Reference ref) async {
+                                  await ref.delete();
+                                });
+                                result.prefixes.forEach((firebase_storage.Reference ref) async {
+                                  if (ref.name == userId) {
+                                    await ref.delete();
+                                  }
+                                });
+
+                                await cloud.collection('users').doc(userId).delete();
+                                
+                                await auth.currentUser.delete();
+
+                                await Navigator.of(context).pushAndRemoveUntil(
+                                  MaterialPageRoute(builder: (context) => StartPage()),
+                                  (_) => false
+                                );
+                              } else {
+                                setState(() {
+                                  infoText = 'ログインメールアドレスを間違っています。';
+                                });
+                              }
+                            } on FirebaseAuthException catch (error) {
+                              // 登録に失敗した場合
+                              setState(() {
+                                infoText = FirebaseAuthExceptionHandler.exceptionMessage(FirebaseAuthExceptionHandler.handleException(error));
+                              });
+                            } on Exception catch (e) {
+                              // 登録に失敗した場合
+                              setState(() {
+                                infoText = "認証NG: $e";
+                              });
+                            }
+                            Navigator.of(context).pop();
+                          } else {
+                            setState(() {
+                              isEmailEmpty = emailController.text.isEmpty;
+                              isPassEmpty = passController.text.isEmpty;
+                            });
+                          }
+                        },
+                        child: Text("アカウント削除"),
+                        style: ElevatedButton.styleFrom(
+                          primary: AppColor.shadow,
+                          onPrimary: AppColor.white,
+                        ),
+                      ),
+                      Text(
+                        infoText,
+                        style: TextStyle(color: Colors.red),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/goalselect.dart
+++ b/lib/views/goalselect.dart
@@ -85,10 +85,10 @@ class _GoalSelectPageState extends State<GoalSelectPage> {
             await Navigator.of(context).push(
               MaterialPageRoute(builder: (context) => PostViewPage()),
             );
+            DocumentSnapshot userData = await cloud.collection('users').doc(userId).get();
             setState(() {
-              user = FirebaseAuth.instance.currentUser;
-              userName = user.displayName;
-              userPhoto = user.photoURL;
+              userName = userData['userName'];
+              userPhoto = userData['userPhotoUrl'];
             });
           }
         },
@@ -125,10 +125,10 @@ class _GoalSelectPageState extends State<GoalSelectPage> {
                 await Navigator.of(context).push(
                   MaterialPageRoute(builder: (context) => SettingPage()),
                 );
+                DocumentSnapshot userData = await cloud.collection('users').doc(userId).get();
                 setState(() {
-                  user = FirebaseAuth.instance.currentUser;
-                  userName = user.displayName;
-                  userPhoto = user.photoURL;
+                  userName = userData['userName'];
+                  userPhoto = userData['userPhotoUrl'];
                 });
               },
             ),

--- a/lib/views/goalselect.dart
+++ b/lib/views/goalselect.dart
@@ -39,8 +39,8 @@ class _GoalSelectPageState extends State<GoalSelectPage> {
     userId = user.uid;
     userEmail = user.email;
     DocumentSnapshot userData = await cloud.collection('users').doc(userId).get();
-    userName = userData['userName'];
-    userPhoto = userData['userPhotoUrl'];
+    userName = await userData['userName'];
+    userPhoto = await userData['userPhotoUrl'];
 
     setState(() {
       _loading = false;
@@ -80,11 +80,16 @@ class _GoalSelectPageState extends State<GoalSelectPage> {
             label: 'みんなの我慢',
           ),
         ],
-        onTap: (int index) {
+        onTap: (int index) async {
           if (index == 1) {
-            Navigator.of(context).push(
+            await Navigator.of(context).push(
               MaterialPageRoute(builder: (context) => PostViewPage()),
             );
+            setState(() {
+              user = FirebaseAuth.instance.currentUser;
+              userName = user.displayName;
+              userPhoto = user.photoURL;
+            });
           }
         },
         fixedColor: AppColor.priceColor,

--- a/lib/views/goalselect.dart
+++ b/lib/views/goalselect.dart
@@ -30,8 +30,6 @@ class _GoalSelectPageState extends State<GoalSelectPage> {
   @override
   void initState() {
     super.initState();
-    user.reload();
-    user = FirebaseAuth.instance.currentUser;
     if (user != null) {
       setData();
     }
@@ -40,8 +38,9 @@ class _GoalSelectPageState extends State<GoalSelectPage> {
   void setData() async {
     userId = user.uid;
     userEmail = user.email;
-    userName = user.displayName;
-    userPhoto = user.photoURL;
+    DocumentSnapshot userData = await cloud.collection('users').doc(userId).get();
+    userName = userData['userName'];
+    userPhoto = userData['userPhotoUrl'];
 
     setState(() {
       _loading = false;

--- a/lib/views/goalselect.dart
+++ b/lib/views/goalselect.dart
@@ -172,10 +172,11 @@ class _GoalSelectPageState extends State<GoalSelectPage> {
                         margin: EdgeInsets.all(0.5),
                         elevation: 2.0,
                         child: InkWell(
-                          onTap: () {
-                            Navigator.of(context).push(
+                          onTap: () async {
+                            await Navigator.of(context).push(
                               MaterialPageRoute(builder: (context) => HomePage(document.id)),
                             );
+                            setState(() {});
                           },
                           onLongPress: () {
                             showDialog(

--- a/lib/views/goalselect.dart
+++ b/lib/views/goalselect.dart
@@ -103,7 +103,7 @@ class _GoalSelectPageState extends State<GoalSelectPage> {
                   decoration: BoxDecoration(
                     shape: BoxShape.circle,
                     image: DecorationImage(
-                      fit: BoxFit.fill,
+                      fit: BoxFit.cover,
                       image:NetworkImage(userPhoto),
                     ),
                   ),

--- a/lib/views/goalset.dart
+++ b/lib/views/goalset.dart
@@ -22,8 +22,6 @@ class _GoalSetPageState extends State<GoalSetPage> {
   var userId;
 
   bool _loading = true;
-  bool isGoalEmpty = false;
-  bool isWantThingEmpty = false;
 
   @override
   void initState() {
@@ -54,127 +52,126 @@ class _GoalSetPageState extends State<GoalSetPage> {
         ),
         backgroundColor: AppColor.white,
       ),
-      body: LayoutBuilder(
-        builder: (context, constraints) => SingleChildScrollView(
-          physics: AlwaysScrollableScrollPhysics(),
-          child: ConstrainedBox(
-            constraints: BoxConstraints(minHeight: constraints.maxHeight),
-            child: Center(
-              child: Container(
-                color: AppColor.white,
-                padding: EdgeInsets.all(20.0),
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  mainAxisSize: MainAxisSize.min,
-                  children: <Widget>[
-                    Text(
-                      '我慢目的',
-                      style: TextStyle(
-                        fontSize: 16.0,
-                        fontWeight: FontWeight.w500,
-                        color: AppColor.shadow,
+      body: GestureDetector(
+        onTap: () {
+          FocusScope.of(context).unfocus();
+        },
+        child: LayoutBuilder(
+          builder: (context, constraints) => SingleChildScrollView(
+            physics: AlwaysScrollableScrollPhysics(),
+            child: ConstrainedBox(
+              constraints: BoxConstraints(minHeight: constraints.maxHeight),
+              child: Center(
+                child: Container(
+                  color: AppColor.white,
+                  padding: EdgeInsets.all(20.0),
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: <Widget>[
+                      Text(
+                        '我慢目的',
+                        style: TextStyle(
+                          fontSize: 16.0,
+                          fontWeight: FontWeight.w500,
+                          color: AppColor.shadow,
+                        ),
                       ),
-                    ),
-                    TextField(
-                      controller: goalTextController,
-                      style: TextStyle(
-                        fontSize: 18.0,
-                        fontWeight: FontWeight.w400,
+                      TextFormField(
+                        controller: goalTextController,
+                        style: TextStyle(
+                          fontSize: 18.0,
+                          fontWeight: FontWeight.w400,
+                        ),
+                        maxLength: 20,
+                        decoration: InputDecoration(
+                          hintText: '(例)ディスプレイが欲しい！',
+                        ),
+                        validator: (String value) {
+                          return (value == '') ? '我慢目的を入力してください。' : null;
+                        },
+                        autovalidateMode: AutovalidateMode.onUserInteraction,
                       ),
-                      maxLength: 15,
-                      decoration: InputDecoration(
-                        hintText: '(例)ディスプレイが欲しい！',
+                      SizedBox(height: 20.0),
+                      Text(
+                        '欲しいもの',
+                        style: TextStyle(
+                          fontSize: 16.0,
+                          fontWeight: FontWeight.w500,
+                          color: AppColor.shadow,
+                        ),
                       ),
-                    ),
-                    Visibility(
-                      visible: isGoalEmpty,
-                      child: Text(
-                        "我慢目的を入力してください。(例: ディスプレイが欲しい！）",
-                        style: TextStyle(color: Colors.red, fontSize: 12.0),
+                      Text(
+                        '※ Amazon商品リンクを貼り付けてください.',
+                        style: TextStyle(
+                          fontSize: 10.0,
+                          fontWeight: FontWeight.w500,
+                          color: AppColor.shadow,
+                        ),
                       ),
-                    ),
-                    SizedBox(height: 20.0),
-                    Text(
-                      '欲しいもの',
-                      style: TextStyle(
-                        fontSize: 16.0,
-                        fontWeight: FontWeight.w500,
-                        color: AppColor.shadow,
+                      TextFormField(
+                        controller: wantThingController,
+                        style: TextStyle(
+                          fontSize: 18.0,
+                          fontWeight: FontWeight.w400,
+                        ),
+                        validator: (String value) {
+                          return (value == '') ? '欲しいもののAmazonリンクを貼り付けてください。' : null;
+                        },
+                        autovalidateMode: AutovalidateMode.onUserInteraction,
                       ),
-                    ),
-                    Text(
-                      '※ Amazon商品リンクを貼り付けてください.',
-                      style: TextStyle(
-                        fontSize: 10.0,
-                        fontWeight: FontWeight.w500,
-                        color: AppColor.shadow,
+                      Padding(padding: EdgeInsets.all(30.0),),
+                      Container(
+                        alignment: Alignment.bottomRight,
+                        padding: EdgeInsets.all(10.0),
+                        child: SizedBox(
+                          child: ElevatedButton(
+                            onPressed: (goalTextController.text.isNotEmpty && wantThingController.text.isNotEmpty) ? submitPressed : null,
+                            style: ElevatedButton.styleFrom(
+                              primary: AppColor.priceColor,
+                              onPrimary: AppColor.white,
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(10),
+                              ),
+                            ),
+                            child: Text(
+                              '登録',
+                              style: TextStyle(
+                                color: Colors.white,
+                                fontSize: 24.0,
+                                fontWeight: FontWeight.w700,
+                              ),
+                            ),
+                          ),
+                        ),
                       ),
-                    ),
-                    TextField(
-                      controller: wantThingController,
-                      style: TextStyle(
-                        fontSize: 18.0,
-                        fontWeight: FontWeight.w400,
-                      ),
-                    ),
-                    Visibility(
-                      visible: isWantThingEmpty,
-                      child: Text(
-                        "欲しいモノのAmazon商品リンクを入力してください。",
-                        style: TextStyle(color: Colors.red),
-                      ),
-                    ),
-                    Padding(padding: EdgeInsets.all(30.0),),
-                    Container(
-                      alignment: Alignment.bottomRight,
-                      padding: EdgeInsets.all(10.0),
-                      child: SizedBox(
+                      Padding(padding: EdgeInsets.all(30.0)),
+                      SizedBox(
+                        width: 200.0,
                         child: ElevatedButton(
-                          onPressed: submitPressed,
+                          onPressed: () {
+                            Navigator.of(context).push(
+                              MaterialPageRoute(builder: (context) => GoalSetManualPage()),
+                            );
+                          },
                           style: ElevatedButton.styleFrom(
-                            primary: AppColor.priceColor,
+                            primary: AppColor.shadow,
                             onPrimary: AppColor.white,
                             shape: RoundedRectangleBorder(
                               borderRadius: BorderRadius.circular(10),
                             ),
                           ),
                           child: Text(
-                            '登録',
+                            '手動で登録する',
                             style: TextStyle(
-                              color: Colors.white,
-                              fontSize: 24.0,
-                              fontWeight: FontWeight.w700,
+                              fontWeight: FontWeight.bold
                             ),
                           ),
                         ),
                       ),
-                    ),
-                    Padding(padding: EdgeInsets.all(30.0)),
-                    SizedBox(
-                      width: 200.0,
-                      child: ElevatedButton(
-                        onPressed: () {
-                          Navigator.of(context).push(
-                            MaterialPageRoute(builder: (context) => GoalSetManualPage()),
-                          );
-                        },
-                        style: ElevatedButton.styleFrom(
-                          primary: AppColor.shadow,
-                          onPrimary: AppColor.white,
-                          shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(10),
-                          ),
-                        ),
-                        child: Text(
-                          '手動で登録する',
-                          style: TextStyle(
-                            fontWeight: FontWeight.bold
-                          ),
-                        ),
-                      ),
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
               ),
             ),
@@ -185,7 +182,7 @@ class _GoalSetPageState extends State<GoalSetPage> {
   }
 
   void submitPressed() async {
-    if (goalTextController.text.isNotEmpty && wantThingController.text.isNotEmpty) {
+    if (goalTextController.text.isNotEmpty && wantThingController.text.isNotEmpty && goalTextController.text.length < 21) {
       setState(() {
         _loading = true;
       });
@@ -264,11 +261,6 @@ class _GoalSetPageState extends State<GoalSetPage> {
       );
 
       _loading = false;
-    } else {
-      setState(() {
-        isGoalEmpty = goalTextController.text.isEmpty;
-        isWantThingEmpty = wantThingController.text.isEmpty;
-      });
     }
   }
 

--- a/lib/views/goalset_manual.dart
+++ b/lib/views/goalset_manual.dart
@@ -218,7 +218,7 @@ class _GoalSetManualPageState extends State<GoalSetManualPage> {
   }
 
   void submitPressed() async {
-    if (goalTextController.text.isNotEmpty && wantThingController.text.isNotEmpty && wantThingImg != null && goalTextController.text.length < 8 && wantThingController.text.length < 21) {
+    if (goalTextController.text.isNotEmpty && wantThingController.text.isNotEmpty && wantThingImg != null && goalTextController.text.length < 21 && wantThingController.text.length < 8) {
       setState(() {
         _loading = true;
       });

--- a/lib/views/goalset_manual.dart
+++ b/lib/views/goalset_manual.dart
@@ -88,7 +88,7 @@ class _GoalSetManualPageState extends State<GoalSetManualPage> {
                         ),
                         maxLength: 20,
                         decoration: InputDecoration(
-                          hintText: '(例)旅行に行きたい！',
+                          hintText: '(例)〇〇が欲しい！旅行に行きたい！',
                         ),
                       ),
                       SizedBox(height: 20.0),
@@ -110,7 +110,7 @@ class _GoalSetManualPageState extends State<GoalSetManualPage> {
                                 '￥ ',
                                 style: TextStyle(fontSize: 18.0, fontWeight: FontWeight.w500, color: AppColor.textColor),
                               ),
-                              SizedBox(height: 24.0),
+                              SizedBox(height: 21.0),
                             ],
                           ),
                           Flexible(

--- a/lib/views/goalset_manual.dart
+++ b/lib/views/goalset_manual.dart
@@ -24,9 +24,6 @@ class _GoalSetManualPageState extends State<GoalSetManualPage> {
   var wantThingImg;
 
   bool _loading = true;
-  bool isGoalEmpty = false;
-  bool isPriceEmpty = false;
-  bool isWantThingImgEmpty = false;
 
   @override
   void initState() {
@@ -57,166 +54,150 @@ class _GoalSetManualPageState extends State<GoalSetManualPage> {
         ),
         backgroundColor: AppColor.white,
       ),
-      body: LayoutBuilder(
-        builder: (context, constraints) => SingleChildScrollView(
-          physics: AlwaysScrollableScrollPhysics(),
-          child: ConstrainedBox(
-            constraints: BoxConstraints(minHeight: constraints.maxHeight),
-            child: Center(
-              child: Container(
-                color: AppColor.white,
-                padding: EdgeInsets.all(20.0),
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  mainAxisSize: MainAxisSize.min,
-                  children: <Widget>[
-                    Text(
-                      '我慢目的',
-                      style: TextStyle(
-                        fontSize: 16.0,
-                        fontWeight: FontWeight.w500,
-                        color: AppColor.shadow,
-                      ),
-                    ),
-                    TextField(
-                      controller: goalTextController,
-                      style: TextStyle(
-                        fontSize: 18.0,
-                        fontWeight: FontWeight.w400,
-                      ),
-                      maxLength: 15,
-                      decoration: InputDecoration(
-                        hintText: '(例)旅行に行きたい！',
-                      ),
-                    ),
-                    Visibility(
-                      visible: isGoalEmpty,
-                      child: Text(
-                        "我慢目的を入力してください。",
-                        style: TextStyle(color: Colors.red),
-                      ),
-                    ),
-                    SizedBox(height: 20.0),
-                    Text(
-                      '欲しいものの値段',
-                      style: TextStyle(
-                        fontSize: 16.0,
-                        fontWeight: FontWeight.w500,
-                        color: AppColor.shadow,
-                      ),
-                    ),
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      crossAxisAlignment: CrossAxisAlignment.center,
-                      children: <Widget>[
-                        Column(
-                          children: <Widget>[
-                            Text(
-                              '￥ ',
-                              style: TextStyle(fontSize: 18.0, fontWeight: FontWeight.w500, color: AppColor.textColor),
-                            ),
-                            SizedBox(height: 24.0),
-                          ],
+      body: GestureDetector(
+        onTap: () {
+          FocusScope.of(context).unfocus();
+        },
+        child: LayoutBuilder(
+          builder: (context, constraints) => SingleChildScrollView(
+            physics: AlwaysScrollableScrollPhysics(),
+            child: ConstrainedBox(
+              constraints: BoxConstraints(minHeight: constraints.maxHeight),
+              child: Center(
+                child: Container(
+                  color: AppColor.white,
+                  padding: EdgeInsets.all(20.0),
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: <Widget>[
+                      Text(
+                        '我慢目的',
+                        style: TextStyle(
+                          fontSize: 16.0,
+                          fontWeight: FontWeight.w500,
+                          color: AppColor.shadow,
                         ),
-                        Flexible(
-                          child: TextField(
-                            keyboardType: TextInputType.number,
-                            controller: wantThingController,
-                            style: TextStyle(
-                              fontSize: 18.0,
-                              fontWeight: FontWeight.w400,
-                            ),
-                            maxLength: 7,
-                            inputFormatters: [FilteringTextInputFormatter.digitsOnly],
-                          ),
-                        ),
-                      ],
-                    ),
-                    Visibility(
-                      visible: isPriceEmpty,
-                      child: Text(
-                        "欲しいものの値段を入力してください。",
-                        style: TextStyle(color: Colors.red),
                       ),
-                    ),
-                    SizedBox(height: 20.0),
-                    Text(
-                      '欲しいものの画像',
-                      style: TextStyle(
-                        fontSize: 16.0,
-                        fontWeight: FontWeight.w500,
-                        color: AppColor.shadow,
-                      ),
-                    ),
-                    GestureDetector(
-                      onTap: uploadImage,
-                      child: (wantThingImg != null) ? Container(
-                        height: 200.0,
-                        width: 150.0,
-                        decoration: BoxDecoration(
-                          borderRadius: BorderRadius.circular(8.0),
-                          image: DecorationImage(
-                            image: FileImage(File(wantThingImg)),
-                            fit: BoxFit.contain,
-                          ),
+                      TextField(
+                        controller: goalTextController,
+                        style: TextStyle(
+                          fontSize: 18.0,
+                          fontWeight: FontWeight.w400,
                         ),
-                      ) : Stack(
-                        alignment: Alignment.center,
+                        maxLength: 20,
+                        decoration: InputDecoration(
+                          hintText: '(例)旅行に行きたい！',
+                        ),
+                      ),
+                      SizedBox(height: 20.0),
+                      Text(
+                        '欲しいものの値段',
+                        style: TextStyle(
+                          fontSize: 16.0,
+                          fontWeight: FontWeight.w500,
+                          color: AppColor.shadow,
+                        ),
+                      ),
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        crossAxisAlignment: CrossAxisAlignment.center,
                         children: <Widget>[
-                          Container(
-                            width: 200.0,
-                            height: 150.0,
-                            decoration: BoxDecoration(
-                              color: AppColor.shadow,
-                              borderRadius: BorderRadius.circular(8.0),
-                            ),
+                          Column(
+                            children: <Widget>[
+                              Text(
+                                '￥ ',
+                                style: TextStyle(fontSize: 18.0, fontWeight: FontWeight.w500, color: AppColor.textColor),
+                              ),
+                              SizedBox(height: 24.0),
+                            ],
                           ),
-                          Text(
-                            '+',
-                            style: TextStyle(
-                              color: AppColor.white,
-                              fontSize: 40.0,
-                              fontWeight: FontWeight.w500,
+                          Flexible(
+                            child: TextField(
+                              keyboardType: TextInputType.number,
+                              controller: wantThingController,
+                              style: TextStyle(
+                                fontSize: 18.0,
+                                fontWeight: FontWeight.w400,
+                              ),
+                              maxLength: 7,
+                              inputFormatters: [FilteringTextInputFormatter.digitsOnly],
                             ),
                           ),
                         ],
                       ),
-                    ),
-                    Visibility(
-                      visible: isWantThingImgEmpty,
-                      child: Text(
-                        "欲しいものの画像を選択してください。",
-                        style: TextStyle(color: Colors.red),
+                      SizedBox(height: 20.0),
+                      Text(
+                        '欲しいものの画像',
+                        style: TextStyle(
+                          fontSize: 16.0,
+                          fontWeight: FontWeight.w500,
+                          color: AppColor.shadow,
+                        ),
                       ),
-                    ),
-                    Padding(padding: EdgeInsets.all(20.0),),
-                    Container(
-                      alignment: Alignment.bottomRight,
-                      padding: EdgeInsets.all(10.0),
-                      child: SizedBox(
-                        child: ElevatedButton(
-                          onPressed: submitPressed,
-                          style: ElevatedButton.styleFrom(
-                            primary: AppColor.priceColor,
-                            onPrimary: AppColor.white,
-                            shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(10),
+                      GestureDetector(
+                        onTap: uploadImage,
+                        child: (wantThingImg != null) ? Container(
+                          height: 200.0,
+                          width: 150.0,
+                          decoration: BoxDecoration(
+                            borderRadius: BorderRadius.circular(8.0),
+                            image: DecorationImage(
+                              image: FileImage(File(wantThingImg)),
+                              fit: BoxFit.contain,
                             ),
                           ),
-                          child: Text(
-                            '登録',
-                            style: TextStyle(
-                              color: Colors.white,
-                              fontSize: 24.0,
-                              fontWeight: FontWeight.w700,
+                        ) : Stack(
+                          alignment: Alignment.center,
+                          children: <Widget>[
+                            Container(
+                              width: 200.0,
+                              height: 150.0,
+                              decoration: BoxDecoration(
+                                color: AppColor.shadow,
+                                borderRadius: BorderRadius.circular(8.0),
+                              ),
+                            ),
+                            Text(
+                              '+',
+                              style: TextStyle(
+                                color: AppColor.white,
+                                fontSize: 40.0,
+                                fontWeight: FontWeight.w500,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                      Padding(padding: EdgeInsets.all(20.0),),
+                      Container(
+                        alignment: Alignment.bottomRight,
+                        padding: EdgeInsets.all(10.0),
+                        child: SizedBox(
+                          child: ElevatedButton(
+                            onPressed: (goalTextController.text.isNotEmpty && wantThingController.text.isNotEmpty && wantThingImg != null) ? submitPressed : null,
+                            style: ElevatedButton.styleFrom(
+                              primary: AppColor.priceColor,
+                              onPrimary: AppColor.white,
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(10),
+                              ),
+                            ),
+                            child: Text(
+                              '登録',
+                              style: TextStyle(
+                                color: Colors.white,
+                                fontSize: 24.0,
+                                fontWeight: FontWeight.w700,
+                              ),
                             ),
                           ),
                         ),
                       ),
-                    ),
-                    Padding(padding: EdgeInsets.all(30.0)),
-                  ],
+                      Padding(padding: EdgeInsets.all(30.0)),
+                    ],
+                  ),
                 ),
               ),
             ),
@@ -237,7 +218,7 @@ class _GoalSetManualPageState extends State<GoalSetManualPage> {
   }
 
   void submitPressed() async {
-    if (goalTextController.text.isNotEmpty && wantThingController.text.isNotEmpty && wantThingImg != null) {
+    if (goalTextController.text.isNotEmpty && wantThingController.text.isNotEmpty && wantThingImg != null && goalTextController.text.length < 8 && wantThingController.text.length < 21) {
       setState(() {
         _loading = true;
       });
@@ -269,16 +250,6 @@ class _GoalSetManualPageState extends State<GoalSetManualPage> {
       );
 
       _loading = false;
-    } else {
-      setState(() {
-        isGoalEmpty = goalTextController.text.isEmpty;
-        isPriceEmpty = wantThingController.text.isEmpty;
-        if (wantThingImg == null) {
-          isWantThingImgEmpty = true; 
-        } else {
-          isWantThingImgEmpty = false;
-        }
-      });
     }
   }
 }

--- a/lib/views/home.dart
+++ b/lib/views/home.dart
@@ -321,7 +321,7 @@ class _HomePageState extends State<HomePage> {
                                 ],
                               ),
                               trailing: Text(
-                                document['price'].toString(),
+                                '¥' + document['price'].toString(),
                                 style: TextStyle(
                                   color: AppColor.priceColor,
                                   fontSize: 19.0,
@@ -334,6 +334,7 @@ class _HomePageState extends State<HomePage> {
                       )).toList(),
                   ),
                 ),
+                SizedBox(height: 100),
               ],
             ),
           ),

--- a/lib/views/home.dart
+++ b/lib/views/home.dart
@@ -477,7 +477,7 @@ class _HomePageState extends State<HomePage> {
 
   void submitPressed() async {
 
-    if(priceController.text != '' && descriptionController.text != '' && priceController.text.length < 7 && descriptionController.text.length < 21) {
+    if(priceController.text.isNotEmpty && descriptionController.text.isNotEmpty && priceController.text.length < 7 && descriptionController.text.length < 21) {
       Navigator.pop(context);
 
       final time = DateTime.now();

--- a/lib/views/home.dart
+++ b/lib/views/home.dart
@@ -401,7 +401,7 @@ class _HomePageState extends State<HomePage> {
                             '￥ ',
                             style: TextStyle(fontSize: 20.0, fontWeight: FontWeight.w500, color: AppColor.textColor),
                           ),
-                          SizedBox(height: 24.0),
+                          SizedBox(height: 22.5),
                         ],
                       ),
                       Flexible(
@@ -529,19 +529,19 @@ class _HomePageState extends State<HomePage> {
                   children: <Widget>[
                     Image.network(wantThingImg),
                     Text('おめでとうございます！実質貯金が貯まりました。'),
-                    (_url != null) ? Text('商品ページへ遷移しますか？') : Container(),
+                    (_url != null) ? Text('商品ページへ遷移しますか？') : Text('我慢目的を叶えましょう！'),
                   ],
                 ),
               ),
               actions: <Widget>[
-                TextButton(
-                  child: const Text('Cancel'),
+                (_url != null) ? TextButton(
+                  child: const Text('もどる'),
                   onPressed: () {
                     Navigator.of(context).pop();
                   },
-                ),
+                ) : Container(),
                 TextButton(
-                  child: const Text('OK'),
+                  child: const Text('はい'),
                   onPressed: () {
                     (_url != null) ? _launchURL() : Container();
                     Navigator.of(context).pop();

--- a/lib/views/home.dart
+++ b/lib/views/home.dart
@@ -574,6 +574,9 @@ class _HomePageState extends State<HomePage> {
       });
       _currentValue = (saving / int.parse(wantThingPrice)) * 100;
     });
+    if (saving < int.parse(wantThingPrice)) {
+      await cloud.collection('goals').doc(goalId).update({'achieve': false});
+    }
   }
 
   void errorDialog() {

--- a/lib/views/home.dart
+++ b/lib/views/home.dart
@@ -29,10 +29,7 @@ class _HomePageState extends State<HomePage> {
 
   var user = FirebaseAuth.instance.currentUser;
   var cloud = FirebaseFirestore.instance;
-  var userEmail;
   var userId;
-  var userName;
-  var userPhoto;
   var wantThingPrice;
   var wantThingImg;
   var wantThingText;
@@ -54,9 +51,6 @@ class _HomePageState extends State<HomePage> {
   }
 
   void setData() async {
-    userEmail = user.email;
-    userName = user.displayName;
-    userPhoto = user.photoURL;
     userId = user.uid;
     DocumentSnapshot goalSnapshot = await cloud.collection('goals').doc(goalId).get();
     wantThingPrice = goalSnapshot['wantThingPrice'].replaceAll(',', '').replaceAll('￥', '');

--- a/lib/views/home.dart
+++ b/lib/views/home.dart
@@ -414,6 +414,10 @@ class _HomePageState extends State<HomePage> {
                           keyboardType: TextInputType.number,
                           inputFormatters: [FilteringTextInputFormatter.digitsOnly],
                           maxLength: 6,
+                          validator: (String value) {
+                            return (value == '') ? '価格を入力してください。' : null;
+                          },
+                          autovalidateMode: AutovalidateMode.onUserInteraction,
                         ),
                       ),
                     ],
@@ -427,7 +431,7 @@ class _HomePageState extends State<HomePage> {
                       color: AppColor.shadow,
                     ),
                   ),
-                  TextField(
+                  TextFormField(
                     controller: descriptionController,
                     style: TextStyle(
                       fontSize: 18.0,
@@ -438,6 +442,10 @@ class _HomePageState extends State<HomePage> {
                       hintStyle: TextStyle(fontSize: 16.0,),
                     ),
                     maxLength: 20,
+                    validator: (String value) {
+                      return (value == '') ? '内容を入力してください。' : null;
+                    },
+                    autovalidateMode: AutovalidateMode.onUserInteraction,
                   ),
                   Padding(padding: EdgeInsets.all(40.0),),
                   Container(
@@ -445,7 +453,7 @@ class _HomePageState extends State<HomePage> {
                     padding: EdgeInsets.all(10.0),
                     child: SizedBox(
                       child: ElevatedButton(
-                        onPressed: submitPressed,
+                        onPressed: (priceController.text.isNotEmpty && descriptionController.text.isNotEmpty) ? submitPressed : null,
                         style: ElevatedButton.styleFrom(
                           primary: AppColor.priceColor,
                           onPrimary: AppColor.white,
@@ -474,9 +482,10 @@ class _HomePageState extends State<HomePage> {
   }
 
   void submitPressed() async {
-    Navigator.pop(context);
 
-    if(priceController.text != '' && descriptionController.text != '') {
+    if(priceController.text != '' && descriptionController.text != '' && priceController.text.length < 7 && descriptionController.text.length < 21) {
+      Navigator.pop(context);
+
       final time = DateTime.now();
       final createdAt = Timestamp.fromDate(time);
       final date = DateFormat('yyyy-MM-dd HH:mm').format(time).toString();

--- a/lib/views/mailcheck.dart
+++ b/lib/views/mailcheck.dart
@@ -20,6 +20,7 @@ class _Emailcheck extends State<Emailcheck> {
   final auth = FirebaseAuth.instance;
   String _sentEmailText;
   String _nocheckText = '';
+  String infoText = '';
 
   @override
   Widget build(BuildContext context) {
@@ -32,16 +33,15 @@ class _Emailcheck extends State<Emailcheck> {
         child:Column(
           mainAxisSize: MainAxisSize.min,
           children: [
+            // 確認メール送信時のメッセージ
+            Text(_sentEmailText),
             Padding(
-              padding: EdgeInsets.fromLTRB(20.0, 0, 20.0, 20.0),
+              padding: EdgeInsets.fromLTRB(20.0, 0, 20.0, 0),
               child: Text(
-                _nocheckText,
+                infoText,
                 style: TextStyle(color: Colors.red),
               ),
             ),
-
-            // 確認メール送信時のメッセージ
-            Text(_sentEmailText),
 
             // 確認メールの再送信ボタン
             Padding(
@@ -50,9 +50,16 @@ class _Emailcheck extends State<Emailcheck> {
                 width: 200.0,
                 child: ElevatedButton(
                   onPressed: () async {
-                    ShowProgress.showProgressDialog(context);
-                    await auth.currentUser.sendEmailVerification();
-                    Navigator.of(context).pop();
+                    try {
+                      ShowProgress.showProgressDialog(context);
+                      await auth.currentUser.sendEmailVerification();
+                      Navigator.of(context).pop();
+                    } on FirebaseAuthException {
+                      Navigator.of(context).pop();
+                      setState(() {
+                        infoText = '確認メールの送信上限に達しました。\nしばらく経ってからお試しください。';
+                      });
+                    }
                   },
                   style: ElevatedButton.styleFrom(
                     primary: AppColor.shadow,
@@ -68,7 +75,7 @@ class _Emailcheck extends State<Emailcheck> {
                 ),
               ),
             ),
-
+            
             // メール確認完了のボタン配置（Home画面に遷移）
             SizedBox(
               width: 350.0,
@@ -107,6 +114,13 @@ class _Emailcheck extends State<Emailcheck> {
                     fontWeight: FontWeight.bold
                   ),
                 ),
+              ),
+            ),
+            Padding(
+              padding: EdgeInsets.fromLTRB(20.0, 0, 20.0, 20.0),
+              child: Text(
+                _nocheckText,
+                style: TextStyle(color: Colors.red),
               ),
             ),
           ],

--- a/lib/views/postview.dart
+++ b/lib/views/postview.dart
@@ -225,10 +225,10 @@ class _PostViewPageState extends State<PostViewPage> {
                                   ],
                                 ),
                                 trailing: Text(
-                                  document['price'].toString(),
+                                  '¥' + document['price'].toString(),
                                   style: TextStyle(
                                     color: AppColor.priceColor,
-                                    fontSize: 20.0,
+                                    fontSize: 18.0,
                                     fontWeight: FontWeight.w700,
                                   ),
                                 ),

--- a/lib/views/postview.dart
+++ b/lib/views/postview.dart
@@ -17,6 +17,7 @@ class _PostViewPageState extends State<PostViewPage> {
 
   var cloud = FirebaseFirestore.instance;
   var user = FirebaseAuth.instance.currentUser;
+  var userId;
   var userName;
   var userPhoto;
   var userEmail;
@@ -32,9 +33,11 @@ class _PostViewPageState extends State<PostViewPage> {
   }
 
   void setData() async {
-    userName = user.displayName;
-    userPhoto = user.photoURL;
+    userId = user.uid;
     userEmail = user.email;
+    DocumentSnapshot userData = await cloud.collection('users').doc(userId).get();
+    userName = await userData['userName'];
+    userPhoto = await userData['userPhotoUrl'];
 
     setState(() {
       _loading = false;

--- a/lib/views/postview.dart
+++ b/lib/views/postview.dart
@@ -197,7 +197,7 @@ class _PostViewPageState extends State<PostViewPage> {
                                     Text(
                                       userData['userName'],
                                       style: TextStyle(
-                                        fontSize: 16.0,
+                                        fontSize: 14.0,
                                         fontWeight: FontWeight.w700,
                                       ),
                                     ),
@@ -213,12 +213,12 @@ class _PostViewPageState extends State<PostViewPage> {
                                 subtitle: Column(
                                   crossAxisAlignment: CrossAxisAlignment.start,
                                   children: <Widget>[
-                                    Padding(padding: EdgeInsets.all(3.0)),
+                                    Padding(padding: EdgeInsets.all(1.0)),
                                     Text(
                                       document['text'],
                                       style: TextStyle(
                                         color: AppColor.textColor,
-                                        fontSize: 15.0,
+                                        fontSize: 14.0,
                                         fontWeight: FontWeight.w400,
                                       ),
                                     ),
@@ -228,7 +228,7 @@ class _PostViewPageState extends State<PostViewPage> {
                                   '¥' + document['price'].toString(),
                                   style: TextStyle(
                                     color: AppColor.priceColor,
-                                    fontSize: 18.0,
+                                    fontSize: 16.0,
                                     fontWeight: FontWeight.w700,
                                   ),
                                 ),

--- a/lib/views/postview.dart
+++ b/lib/views/postview.dart
@@ -75,7 +75,7 @@ class _PostViewPageState extends State<PostViewPage> {
                   decoration: BoxDecoration(
                     shape: BoxShape.circle,
                     image: DecorationImage(
-                      fit: BoxFit.fill,
+                      fit: BoxFit.cover,
                       image:NetworkImage(userPhoto),
                     ),
                   ),

--- a/lib/views/postview.dart
+++ b/lib/views/postview.dart
@@ -96,10 +96,10 @@ class _PostViewPageState extends State<PostViewPage> {
                 await Navigator.of(context).push(
                   MaterialPageRoute(builder: (context) => SettingPage()),
                 );
+                DocumentSnapshot userData = await cloud.collection('users').doc(userId).get();
                 setState(() {
-                  user = FirebaseAuth.instance.currentUser;
-                  userName = user.displayName;
-                  userPhoto = user.photoURL;
+                  userName = userData['userName'];
+                  userPhoto = userData['userPhotoUrl'];
                 });
               },
             ),

--- a/lib/views/reset_password.dart
+++ b/lib/views/reset_password.dart
@@ -1,9 +1,9 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
+import 'package:my_gaman_app/models/firebase_error.dart';
 import '../configs/colors.dart';
 import '../main.dart';
-import 'goalselect.dart';
+import 'login.dart';
 
 class ResetPassPage extends StatefulWidget {
   @override
@@ -54,9 +54,11 @@ class _ResetPassPageState extends State<ResetPassPage> {
                           isEmailEmpty = false;
                           try {
                             final FirebaseAuth auth = FirebaseAuth.instance;
+                            await auth.sendPasswordResetEmail(email: emailController.text);
                             if (auth.currentUser != null) {
+                              await auth.signOut();
                               Navigator.of(context).pushAndRemoveUntil(
-                                MaterialPageRoute(builder: (context) => GoalSelectPage()),
+                                MaterialPageRoute(builder: (context) => MyLoginPage()),
                                 (_) => false,
                               );
                             } else {
@@ -65,16 +67,15 @@ class _ResetPassPageState extends State<ResetPassPage> {
                                 (_) => false,
                               );
                             }
-                            await auth.sendPasswordResetEmail(email: emailController.text);
-                          } on PlatformException catch (error) {
+                          } on FirebaseAuthException catch (error) {
                             // 登録に失敗した場合
                             setState(() {
-                              infoText = "登録NG：${error.message}";
+                              infoText = FirebaseAuthExceptionHandler.exceptionMessage(FirebaseAuthExceptionHandler.handleException(error));
                             });
                           } on Exception catch (e) {
                             // 登録に失敗した場合
                             setState(() {
-                              infoText = "登録NG: $e";
+                              infoText = "認証NG: $e";
                             });
                           }
                         } else {

--- a/lib/views/setting.dart
+++ b/lib/views/setting.dart
@@ -54,7 +54,6 @@ class _SettingPageState extends State<SettingPage> {
     }
 
     return Scaffold(
-      backgroundColor: AppColor.bgColor,
       appBar: AppBar(
         iconTheme: IconThemeData(color: Colors.grey),
         title: Text(
@@ -67,132 +66,136 @@ class _SettingPageState extends State<SettingPage> {
         backgroundColor: AppColor.white,
       ),
 
-      body: Container(
-        color: AppColor.bgColor,
-        margin: EdgeInsets.only(top: 30),
-        padding: EdgeInsets.only(left: 20, right: 20),
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.start,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          mainAxisSize: MainAxisSize.max,
-          children: <Widget>[
-            GestureDetector(
-              onTap: uploadImage,
-              child: Stack(
-                alignment: Alignment.center,
-                children: <Widget>[
-                  Container(
-                    height: 55.0,
-                    width: 55.0,
-                    decoration: BoxDecoration(
-                      borderRadius: BorderRadius.circular(8.0),
-                      image: DecorationImage(
-                        image: NetworkImage(userPhoto),
-                        fit: BoxFit.cover,
+      body: GestureDetector(
+        onTap: () {
+          FocusScope.of(context).unfocus();
+        },
+        child: Container(
+          margin: EdgeInsets.only(top: 30),
+          padding: EdgeInsets.only(left: 20, right: 20),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.start,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.max,
+            children: <Widget>[
+              GestureDetector(
+                onTap: uploadImage,
+                child: Stack(
+                  alignment: Alignment.center,
+                  children: <Widget>[
+                    Container(
+                      height: 55.0,
+                      width: 55.0,
+                      decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(8.0),
+                        image: DecorationImage(
+                          image: NetworkImage(userPhoto),
+                          fit: BoxFit.cover,
+                        ),
                       ),
                     ),
-                  ),
-                  Container(
-                    width: 55.0,
-                    height: 55.0,
-                    decoration: BoxDecoration(
-                      color: AppColor.curtain,
-                      borderRadius: BorderRadius.circular(8.0),
+                    Container(
+                      width: 55.0,
+                      height: 55.0,
+                      decoration: BoxDecoration(
+                        color: AppColor.curtain,
+                        borderRadius: BorderRadius.circular(8.0),
+                      ),
                     ),
-                  ),
-                  Text(
-                    '+',
-                    style: TextStyle(
-                      color: AppColor.textColor,
-                      fontSize: 40.0,
-                      fontWeight: FontWeight.w500,
+                    Text(
+                      '+',
+                      style: TextStyle(
+                        color: AppColor.textColor,
+                        fontSize: 40.0,
+                        fontWeight: FontWeight.w500,
+                      ),
                     ),
-                  ),
-                ],
-              ),
-            ),
-            Padding(padding: EdgeInsets.all(10.0)),
-            Text(
-              'ユーザー名',
-              style: TextStyle(
-                color: AppColor.shadow,
-                fontSize: 14.0,
-                fontWeight: FontWeight.w200,
-              ),
-            ),
-            TextFormField(
-              controller: userNameController,
-              style: TextStyle(
-                color: AppColor.textColor,
-                fontSize: 18.0,
-                fontWeight: FontWeight.w400,
-              ),
-              maxLength: 15,
-              validator: (String value) {
-                return (value == '') ? 'ユーザー名を入力してください。' : null;
-              },
-              autovalidateMode: AutovalidateMode.onUserInteraction,
-            ),
-            Padding(padding: EdgeInsets.all(15.0)),
-            Container(
-              alignment: Alignment.bottomRight,
-              child: ElevatedButton(
-                onPressed: saveUsers,
-                child: Text("保存"),
-                style: ElevatedButton.styleFrom(
-                  primary: AppColor.priceColor,
-                  onPrimary: AppColor.white,
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(10),
-                  ),
+                  ],
                 ),
               ),
-            ),
-            SizedBox(height: 30.0),
-            SizedBox(
-              width: 200,
-              child: ElevatedButton(
-                onPressed: () {
-                  showDialog(
-                    context: context,
-                    barrierDismissible: true,
-                    builder: (BuildContext context) {
-                      return AlertDialog(
-                        title: Text('確認'),
-                        content: SingleChildScrollView(
-                          child: ListBody(
-                            children: <Widget>[
-                              Text('本当に削除しますか？'),
-                            ],
-                          ),
-                        ),
-                        actions: <Widget>[
-                          TextButton(
-                            child: const Text('Cancel'),
-                            onPressed: () {
-                              Navigator.of(context).pop();
-                            },
-                          ),
-                          TextButton(
-                            child: const Text('OK'),
-                            onPressed: deleteUser,
-                          ),
-                        ],
-                      );
-                    },
-                  );
+              Padding(padding: EdgeInsets.all(10.0)),
+              Text(
+                'ユーザー名',
+                style: TextStyle(
+                  color: AppColor.shadow,
+                  fontSize: 14.0,
+                  fontWeight: FontWeight.w200,
+                ),
+              ),
+              TextFormField(
+                controller: userNameController,
+                style: TextStyle(
+                  color: AppColor.textColor,
+                  fontSize: 18.0,
+                  fontWeight: FontWeight.w400,
+                ),
+                maxLength: 15,
+                validator: (String value) {
+                  return (value == '') ? 'ユーザー名を入力してください。' : null;
                 },
-                style: ElevatedButton.styleFrom(
-                  primary: AppColor.shadow,
-                  onPrimary: AppColor.white,
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(10),
+                autovalidateMode: AutovalidateMode.onUserInteraction,
+              ),
+              Padding(padding: EdgeInsets.all(15.0)),
+              Container(
+                alignment: Alignment.bottomRight,
+                child: ElevatedButton(
+                  onPressed: (userNameController.text.isNotEmpty) ? saveUsers : null,
+                  child: Text("保存"),
+                  style: ElevatedButton.styleFrom(
+                    primary: AppColor.priceColor,
+                    onPrimary: AppColor.white,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(10),
+                    ),
                   ),
                 ),
-                child: Text("アカウント削除"),
               ),
-            ),
-          ],
+              SizedBox(height: 30.0),
+              SizedBox(
+                width: 200,
+                child: ElevatedButton(
+                  onPressed: () {
+                    showDialog(
+                      context: context,
+                      barrierDismissible: true,
+                      builder: (BuildContext context) {
+                        return AlertDialog(
+                          title: Text('確認'),
+                          content: SingleChildScrollView(
+                            child: ListBody(
+                              children: <Widget>[
+                                Text('本当に削除しますか？'),
+                              ],
+                            ),
+                          ),
+                          actions: <Widget>[
+                            TextButton(
+                              child: const Text('Cancel'),
+                              onPressed: () {
+                                Navigator.of(context).pop();
+                              },
+                            ),
+                            TextButton(
+                              child: const Text('OK'),
+                              onPressed: deleteUser,
+                            ),
+                          ],
+                        );
+                      },
+                    );
+                  },
+                  style: ElevatedButton.styleFrom(
+                    primary: AppColor.shadow,
+                    onPrimary: AppColor.white,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(10),
+                    ),
+                  ),
+                  child: Text("アカウント削除"),
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );
@@ -273,7 +276,7 @@ class _SettingPageState extends State<SettingPage> {
   }
 
   void saveUsers() async {
-    if (userNameController.text != '') {
+    if (userNameController.text != '' && userNameController.text.length < 16) {
       setState(() {
         _loading = true;
       });

--- a/lib/views/setting.dart
+++ b/lib/views/setting.dart
@@ -264,7 +264,9 @@ class _SettingPageState extends State<SettingPage> {
   void uploadImage() async {
     ShowProgress.showProgressDialog(context);
     var image = await UploadImage.getImage(true);
-    userPhoto = await UploadImage.uploadFile(image, userId);
+    if (image != null) {
+      userPhoto = await UploadImage.uploadFile(image, userId);
+    }
     Navigator.of(context).pop();
     setState(() {});
   }

--- a/lib/views/setting.dart
+++ b/lib/views/setting.dart
@@ -127,6 +127,7 @@ class _SettingPageState extends State<SettingPage> {
                 fontSize: 18.0,
                 fontWeight: FontWeight.w400,
               ),
+              maxLength: 15,
               validator: (String value) {
                 return (value == '') ? 'ユーザー名を入力してください。' : null;
               },

--- a/lib/views/setting.dart
+++ b/lib/views/setting.dart
@@ -1,11 +1,9 @@
 import 'dart:io';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:firebase_storage/firebase_storage.dart' as firebase_storage;
 import 'package:flutter/material.dart';
-import 'package:my_gaman_app/main.dart';
 import 'package:my_gaman_app/views/reset_password.dart';
-import 'login.dart';
+import 'delete.dart';
 import '../configs/colors.dart';
 import '../models/upload_image.dart';
 import '../views/show_progress.dart';
@@ -238,8 +236,8 @@ class _SettingPageState extends State<SettingPage> {
                                   TextButton(
                                     child: const Text('OK'),
                                     onPressed: () {
-                                      deleteUser();
                                       Navigator.of(context).pop();
+                                      deleteUser();
                                     },
                                   ),
                                 ],
@@ -267,69 +265,34 @@ class _SettingPageState extends State<SettingPage> {
     );
   }
 
-  void deleteUser() async {
-    try {
-      final gamans = await cloud.collection('gamans').where('userId', isEqualTo: userId).get();
-      final gamandocs = gamans.docs;
-      gamandocs.forEach((gamandoc) async {
-        await cloud.collection('gamans').doc(gamandoc.id).delete();
-      });
-
-      final goals = await cloud.collection('goals').where('userId', isEqualTo: userId).get();
-      final goaldocs = goals.docs;
-      goaldocs.forEach((goaldoc) async {
-        await cloud.collection('goals').doc(goaldoc.id).delete();
-      });
-
-      firebase_storage.ListResult result = await firebase_storage.FirebaseStorage.instance.ref('user/'+userId).listAll();
-      result.items.forEach((firebase_storage.Reference ref) async {
-        await ref.delete();
-      });
-      result.prefixes.forEach((firebase_storage.Reference ref) async {
-        if (ref.name == userId) {
-          await ref.delete();
-        }
-      });
-
-      await cloud.collection('users').doc(userId).delete();
-      
-      await FirebaseAuth.instance.currentUser.delete();
-
-      await Navigator.of(context).pushAndRemoveUntil(
-        MaterialPageRoute(builder: (context) => StartPage()),
-        (_) => false
-      );
-    } on FirebaseAuthException catch (e) {
-      if (e.code == 'requires-recent-login') {
-        showDialog(
-          context: context,
-          barrierDismissible: true,
-          builder: (BuildContext context) {
-            return AlertDialog(
-              title: Text('注意'),
-              content: SingleChildScrollView(
-                child: ListBody(
-                  children: <Widget>[
-                    Text('再度ログインする必要があります。'),
-                  ],
-                ),
-              ),
-              actions: <Widget>[
-                TextButton(
-                  child: const Text('OK'),
-                  onPressed: () {
-                    Navigator.of(context).pop();
-                    Navigator.of(context).pushReplacement(
-                      MaterialPageRoute(builder: (context) => MyLoginPage()),
-                    );
-                  },
-                ),
+  void deleteUser() {
+    showDialog(
+      context: context,
+      barrierDismissible: true,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: Text('注意'),
+          content: SingleChildScrollView(
+            child: ListBody(
+              children: <Widget>[
+                Text('再度ログインする必要があります。'),
               ],
-            );
-          },
+            ),
+          ),
+          actions: <Widget>[
+            TextButton(
+              child: const Text('OK'),
+              onPressed: () {
+                Navigator.of(context).pop();
+                Navigator.of(context).pushReplacement(
+                  MaterialPageRoute(builder: (context) => DeleteLoginPage()),
+                );
+              },
+            ),
+          ],
         );
-      }
-    }
+      },
+    );
   }
 
   void uploadImage() async {

--- a/lib/views/setting.dart
+++ b/lib/views/setting.dart
@@ -70,131 +70,139 @@ class _SettingPageState extends State<SettingPage> {
         onTap: () {
           FocusScope.of(context).unfocus();
         },
-        child: Container(
-          margin: EdgeInsets.only(top: 30),
-          padding: EdgeInsets.only(left: 20, right: 20),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.start,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            mainAxisSize: MainAxisSize.max,
-            children: <Widget>[
-              GestureDetector(
-                onTap: uploadImage,
-                child: Stack(
-                  alignment: Alignment.center,
+        child: LayoutBuilder(
+          builder: (context, constraints) => SingleChildScrollView(
+            physics: AlwaysScrollableScrollPhysics(),
+            child:  ConstrainedBox(
+              constraints: BoxConstraints(minHeight: constraints.maxHeight),
+              child: Container(
+                margin: EdgeInsets.only(top: 30),
+                padding: EdgeInsets.only(left: 20, right: 20),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.start,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.max,
                   children: <Widget>[
+                    GestureDetector(
+                      onTap: uploadImage,
+                      child: Stack(
+                        alignment: Alignment.center,
+                        children: <Widget>[
+                          Container(
+                            height: 55.0,
+                            width: 55.0,
+                            decoration: BoxDecoration(
+                              borderRadius: BorderRadius.circular(8.0),
+                              image: DecorationImage(
+                                image: NetworkImage(userPhoto),
+                                fit: BoxFit.cover,
+                              ),
+                            ),
+                          ),
+                          Container(
+                            width: 55.0,
+                            height: 55.0,
+                            decoration: BoxDecoration(
+                              color: AppColor.curtain,
+                              borderRadius: BorderRadius.circular(8.0),
+                            ),
+                          ),
+                          Text(
+                            '+',
+                            style: TextStyle(
+                              color: AppColor.textColor,
+                              fontSize: 40.0,
+                              fontWeight: FontWeight.w500,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    Padding(padding: EdgeInsets.all(10.0)),
+                    Text(
+                      'ユーザー名',
+                      style: TextStyle(
+                        color: AppColor.shadow,
+                        fontSize: 14.0,
+                        fontWeight: FontWeight.w200,
+                      ),
+                    ),
+                    TextFormField(
+                      controller: userNameController,
+                      style: TextStyle(
+                        color: AppColor.textColor,
+                        fontSize: 18.0,
+                        fontWeight: FontWeight.w400,
+                      ),
+                      maxLength: 15,
+                      validator: (String value) {
+                        return (value == '') ? 'ユーザー名を入力してください。' : null;
+                      },
+                      autovalidateMode: AutovalidateMode.onUserInteraction,
+                    ),
+                    Padding(padding: EdgeInsets.all(15.0)),
                     Container(
-                      height: 55.0,
-                      width: 55.0,
-                      decoration: BoxDecoration(
-                        borderRadius: BorderRadius.circular(8.0),
-                        image: DecorationImage(
-                          image: NetworkImage(userPhoto),
-                          fit: BoxFit.cover,
+                      alignment: Alignment.bottomRight,
+                      child: ElevatedButton(
+                        onPressed: (userNameController.text.isNotEmpty) ? saveUsers : null,
+                        child: Text("保存"),
+                        style: ElevatedButton.styleFrom(
+                          primary: AppColor.priceColor,
+                          onPrimary: AppColor.white,
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(10),
+                          ),
                         ),
                       ),
                     ),
-                    Container(
-                      width: 55.0,
-                      height: 55.0,
-                      decoration: BoxDecoration(
-                        color: AppColor.curtain,
-                        borderRadius: BorderRadius.circular(8.0),
-                      ),
-                    ),
-                    Text(
-                      '+',
-                      style: TextStyle(
-                        color: AppColor.textColor,
-                        fontSize: 40.0,
-                        fontWeight: FontWeight.w500,
+                    SizedBox(height: 30.0),
+                    SizedBox(
+                      width: 200,
+                      child: ElevatedButton(
+                        onPressed: () {
+                          showDialog(
+                            context: context,
+                            barrierDismissible: true,
+                            builder: (BuildContext context) {
+                              return AlertDialog(
+                                title: Text('確認'),
+                                content: SingleChildScrollView(
+                                  child: ListBody(
+                                    children: <Widget>[
+                                      Text('本当に削除しますか？'),
+                                    ],
+                                  ),
+                                ),
+                                actions: <Widget>[
+                                  TextButton(
+                                    child: const Text('Cancel'),
+                                    onPressed: () {
+                                      Navigator.of(context).pop();
+                                    },
+                                  ),
+                                  TextButton(
+                                    child: const Text('OK'),
+                                    onPressed: deleteUser,
+                                  ),
+                                ],
+                              );
+                            },
+                          );
+                        },
+                        style: ElevatedButton.styleFrom(
+                          primary: AppColor.shadow,
+                          onPrimary: AppColor.white,
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(10),
+                          ),
+                        ),
+                        child: Text("アカウント削除"),
                       ),
                     ),
                   ],
                 ),
               ),
-              Padding(padding: EdgeInsets.all(10.0)),
-              Text(
-                'ユーザー名',
-                style: TextStyle(
-                  color: AppColor.shadow,
-                  fontSize: 14.0,
-                  fontWeight: FontWeight.w200,
-                ),
-              ),
-              TextFormField(
-                controller: userNameController,
-                style: TextStyle(
-                  color: AppColor.textColor,
-                  fontSize: 18.0,
-                  fontWeight: FontWeight.w400,
-                ),
-                maxLength: 15,
-                validator: (String value) {
-                  return (value == '') ? 'ユーザー名を入力してください。' : null;
-                },
-                autovalidateMode: AutovalidateMode.onUserInteraction,
-              ),
-              Padding(padding: EdgeInsets.all(15.0)),
-              Container(
-                alignment: Alignment.bottomRight,
-                child: ElevatedButton(
-                  onPressed: (userNameController.text.isNotEmpty) ? saveUsers : null,
-                  child: Text("保存"),
-                  style: ElevatedButton.styleFrom(
-                    primary: AppColor.priceColor,
-                    onPrimary: AppColor.white,
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(10),
-                    ),
-                  ),
-                ),
-              ),
-              SizedBox(height: 30.0),
-              SizedBox(
-                width: 200,
-                child: ElevatedButton(
-                  onPressed: () {
-                    showDialog(
-                      context: context,
-                      barrierDismissible: true,
-                      builder: (BuildContext context) {
-                        return AlertDialog(
-                          title: Text('確認'),
-                          content: SingleChildScrollView(
-                            child: ListBody(
-                              children: <Widget>[
-                                Text('本当に削除しますか？'),
-                              ],
-                            ),
-                          ),
-                          actions: <Widget>[
-                            TextButton(
-                              child: const Text('Cancel'),
-                              onPressed: () {
-                                Navigator.of(context).pop();
-                              },
-                            ),
-                            TextButton(
-                              child: const Text('OK'),
-                              onPressed: deleteUser,
-                            ),
-                          ],
-                        );
-                      },
-                    );
-                  },
-                  style: ElevatedButton.styleFrom(
-                    primary: AppColor.shadow,
-                    onPrimary: AppColor.white,
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(10),
-                    ),
-                  ),
-                  child: Text("アカウント削除"),
-                ),
-              ),
-            ],
+            ),
           ),
         ),
       ),

--- a/lib/views/setting.dart
+++ b/lib/views/setting.dart
@@ -219,13 +219,7 @@ class _SettingPageState extends State<SettingPage> {
                             builder: (BuildContext context) {
                               return AlertDialog(
                                 title: Text('確認'),
-                                content: SingleChildScrollView(
-                                  child: ListBody(
-                                    children: <Widget>[
-                                      Text('本当に削除しますか？'),
-                                    ],
-                                  ),
-                                ),
+                                content: Text('本当に削除しますか？'),
                                 actions: <Widget>[
                                   TextButton(
                                     child: const Text('Cancel'),
@@ -272,13 +266,7 @@ class _SettingPageState extends State<SettingPage> {
       builder: (BuildContext context) {
         return AlertDialog(
           title: Text('注意'),
-          content: SingleChildScrollView(
-            child: ListBody(
-              children: <Widget>[
-                Text('再度ログインする必要があります。'),
-              ],
-            ),
-          ),
+          content: Text('再度ログインする必要があります。'),
           actions: <Widget>[
             TextButton(
               child: const Text('OK'),

--- a/lib/views/signup.dart
+++ b/lib/views/signup.dart
@@ -114,7 +114,7 @@ class _MyAuthPageState extends State<MyAuthPage> {
                       Padding(padding: EdgeInsets.all(30.0)),
                       ElevatedButton(
                         onPressed: () async {
-                          if (emailController.text.isNotEmpty && passController.text.isNotEmpty && userNameController.text.isNotEmpty && passController.text == checkPassController.text && passController.text.length > 7) {
+                          if (emailController.text.isNotEmpty && passController.text.isNotEmpty && userNameController.text.isNotEmpty && passController.text == checkPassController.text && passController.text.length > 7 && userNameController.text.length < 16 && passController.text.length < 31) {
                             isEmailEmpty = false;
                             isPassEmpty = false;
                             isUserNameEmpty = false;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,10 +31,10 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  firebase_core: ^1.0.2
-  firebase_auth: ^1.0.1
-  cloud_firestore: ^1.0.3
-  firebase_storage: ^8.0.1
+  firebase_core: ^1.3.0
+  firebase_auth: ^1.4.1
+  cloud_firestore: ^2.2.2
+  firebase_storage: ^8.1.3
   intl: ^0.17.0
   universal_html: ^2.0.8
   url_launcher: ^6.0.4


### PR DESCRIPTION
変更点
---
- 画像選択時にキャンセルをしてもエラーが出ないように
- setting.dart で、ユーザー画像を選ばずにキャンセルにしてもエラーが出ないように調整。
- setting.dart　でユーザーネームに文字数制限を追加。
- ドロワーメニューでユーザー画像の縦横比が崩れないように調整。
- スクロールしても、我慢履歴がフローティングアクションボタンに隠れないように。
- 文字数を超えた登録はできないように。
- 要件を満たさない場合、ボタンを非アクティブに。
- 目標達成時のダイアログ文言修正
- 目標達成時、チェックマークが更新されていなかったので、goalselect.dart のチェックマークが更新されるように。
- setting.dart のテキストフィールド外タップでキーボードが閉じなかったので修正。
- 画像を選択した後、保存をせずに戻ってもエラーが出ないように。
- ドロワーメニューのために、自分のユーザー情報を取得するロジックを修正。
- パスワード変更ページをブラッシュアップ。
- パスワード変更ページを、アカウント設定画面にも追加。
- アカウント削除時、最近ログインしていなかった場合に挙動がおかしくなってしまっていたので、delete.dart（アカウント削除ページ）を新たに作ることで対応。
- 確認メール再送信は続けてできないので、連続で押された時のエラー処理を追加。